### PR TITLE
move jsonMask prop up for fs api dispatch call.

### DIFF
--- a/source/iml/file-system/file-system-dispatch-source.js
+++ b/source/iml/file-system/file-system-dispatch-source.js
@@ -20,8 +20,7 @@ store.dispatch({
 
 if (ALLOW_ANONYMOUS_READ)
   socketStream('/filesystem', {
-    qs: {
-      jsonMask: noSpace`objects(
+    jsonMask: noSpace`objects(
         id,
         resource_uri,
         label,
@@ -39,6 +38,7 @@ if (ALLOW_ANONYMOUS_READ)
           resource_uri
         )
       )`,
+    qs: {
       limit: 0
     }
   })

--- a/test/spec/iml/file-system/file-system-dispatch-source-test.js
+++ b/test/spec/iml/file-system/file-system-dispatch-source-test.js
@@ -53,9 +53,9 @@ describe('file system dispatch source', () => {
 
   it('should invoke the socket stream', () => {
     expect(mockSocketStream).toHaveBeenCalledOnceWith('/filesystem', {
+      jsonMask:
+        'objects(id,resource_uri,label,locks,name,client_count,bytes_total,bytes_free,available_actions,mgt(primary_server_name,primary_server),mdts(resource_uri))',
       qs: {
-        jsonMask:
-          'objects(id,resource_uri,label,locks,name,client_count,bytes_total,bytes_free,available_actions,mgt(primary_server_name,primary_server),mdts(resource_uri))',
         limit: 0
       }
     });


### PR DESCRIPTION
Fixes #3.

In https://github.com/intel-hpdd/GUI/blob/c1d8fd597d777bbd49aeee830a6b37ca10e5bb3c/source/iml/file-system/file-system-dispatch-source.js#L47 The jsonMask is inside the qs instead of above it. This will cause more data to be fetched then we want, as fs is one of the larger endpoints.

Move jsonMask up.

Signed-off-by: Joe Grund <joe.grund@intel.com>