### PR TITLE
Fix find usage in some resolves.

### DIFF
--- a/source/iml/lnet/lnet-dispatch-source.js
+++ b/source/iml/lnet/lnet-dispatch-source.js
@@ -10,7 +10,12 @@ import socketStream from '../socket/socket-stream.js';
 
 import { ADD_LNET_CONFIGURATION_ITEMS } from './lnet-configuration-reducer.js';
 
-import { ALLOW_ANONYMOUS_READ } from '../environment.js';
+import { CACHE_INITIAL_DATA, ALLOW_ANONYMOUS_READ } from '../environment.js';
+
+store.dispatch({
+  type: ADD_LNET_CONFIGURATION_ITEMS,
+  payload: CACHE_INITIAL_DATA.lnet_configuration
+});
 
 if (ALLOW_ANONYMOUS_READ)
   socketStream('/lnet_configuration', {

--- a/source/iml/server/server-detail-resolves.js
+++ b/source/iml/server/server-detail-resolves.js
@@ -40,7 +40,7 @@ export default function serverDetailResolves($stateParams: { id: string }) {
 
   const serverStream = store
     .select('server')
-    .map(fp.find(x => x.id === $stateParams.id));
+    .map(xs => xs.find(x => x.id === $stateParams.id));
 
   const allHostMatches = {
     qs: {
@@ -52,7 +52,7 @@ export default function serverDetailResolves($stateParams: { id: string }) {
   const lnetConfigurationStream = broadcaster(
     store
       .select('lnetConfiguration')
-      .map(fp.find(x => x.host === `/api/host/${$stateParams.id}/`))
+      .map(xs => xs.find(x => x.host === `/api/host/${$stateParams.id}/`))
   );
 
   const merge = (a, b) => angular.merge(a, b, allHostMatches);

--- a/test/spec/iml/lnet/lnet-dispatch-source-test.js
+++ b/test/spec/iml/lnet/lnet-dispatch-source-test.js
@@ -17,7 +17,20 @@ describe('lnet dispatch source', () => {
       () => mockSocketStream
     );
     jest.mock('../../../../source/iml/environment.js', () => ({
-      ALLOW_ANONYMOUS_READ: true
+      ALLOW_ANONYMOUS_READ: true,
+      CACHE_INITIAL_DATA: {
+        lnet_configuration: {
+          meta: 'meta',
+          objects: [
+            {
+              id: 1
+            },
+            {
+              id: 2
+            }
+          ]
+        }
+      }
     }));
 
     require('../../../../source/iml/lnet/lnet-dispatch-source.js');

--- a/test/spec/iml/server/server-detail-resolves-test.js
+++ b/test/spec/iml/server/server-detail-resolves-test.js
@@ -109,12 +109,10 @@ describe('server detail resolves', () => {
       });
 
       it('should return the server associated with the route', () => {
-        expect(spy).toHaveBeenCalledOnceWith(
-          maybe.ofJust({
-            id: '1',
-            address: 'lotus-35vm15.lotus.hpdd.lab.intel.com'
-          })
-        );
+        expect(spy).toHaveBeenCalledOnceWith({
+          id: '1',
+          address: 'lotus-35vm15.lotus.hpdd.lab.intel.com'
+        });
       });
 
       it('should not return servers which have an id that does not match the route', () => {
@@ -149,15 +147,13 @@ describe('server detail resolves', () => {
       });
 
       it('should return the item associated with the route', () => {
-        expect(spy).toHaveBeenCalledOnceWith(
-          maybe.ofJust({
-            id: '1',
-            host: '/api/host/1/',
-            state: 'lnet_up',
-            resource_uri: '/api/lnet_configuration/1/',
-            label: 'lnet configuration'
-          })
-        );
+        expect(spy).toHaveBeenCalledOnceWith({
+          id: '1',
+          host: '/api/host/1/',
+          state: 'lnet_up',
+          resource_uri: '/api/lnet_configuration/1/',
+          label: 'lnet configuration'
+        });
       });
 
       it('should not return items not associated with the route', () => {


### PR DESCRIPTION
We currently are using `fp.find` in a few resolves where we are not expecting to deal with the `maybe` type.

Switch those resolve to use `Array.prototype.find` instead.