### PR TITLE
Unable to update LNet / Corosync

### DIFF
--- a/source/iml/command/wait-for-command-completion-service.js
+++ b/source/iml/command/wait-for-command-completion-service.js
@@ -14,7 +14,8 @@ import type { Command } from './command-types.js';
 
 export default (openCommandModal: Function) => {
   'ngInject';
-  return (showModal: boolean, response: Command[]) => {
+
+  return (showModal: boolean) => (response: Command[]) => {
     const command$ = getCommandStream(response).map(fp.map(setState));
 
     if (showModal) {

--- a/source/iml/lnet/configure-lnet.js
+++ b/source/iml/lnet/configure-lnet.js
@@ -1,3 +1,5 @@
+// @flow
+
 //
 // Copyright (c) 2017 Intel Corporation. All rights reserved.
 // Use of this source code is governed by a MIT-style
@@ -7,11 +9,11 @@ import * as fp from '@iml/fp';
 import socketStream from '../socket/socket-stream.js';
 
 export function ConfigureLnetController(
-  $scope,
-  LNET_OPTIONS,
-  insertHelpFilter,
-  waitForCommandCompletion,
-  propagateChange
+  $scope: Object,
+  LNET_OPTIONS: Object,
+  insertHelpFilter: Function,
+  waitForCommandCompletion: Function,
+  propagateChange: Function
 ) {
   'ngInject';
   const ctrl = this;

--- a/source/iml/server/create-host-profiles-stream.js
+++ b/source/iml/server/create-host-profiles-stream.js
@@ -112,7 +112,7 @@ export function createHostProfilesFactory(waitForCommandCompletion) {
       .map(fp.map(x => x.commands[0]))
       .flatMap(
         x =>
-          x.length ? waitForCommandCompletion(showCommands, x) : highland([])
+          x.length ? waitForCommandCompletion(showCommands)(x) : highland([])
       );
   };
 }

--- a/source/iml/server/select-server-profile-step.js
+++ b/source/iml/server/select-server-profile-step.js
@@ -192,7 +192,7 @@ export function selectServerProfileStep() {
         fp.map(x => x.command),
         fp.filter(Boolean),
         x =>
-          x.length ? waitForCommandCompletion(showCommand, x) : highland([])
+          x.length ? waitForCommandCompletion(showCommand)(x) : highland([])
       );
 
       const hostProfileStream = createOrUpdateHostsStream(data.servers)

--- a/source/iml/server/server-detail-resolves.js
+++ b/source/iml/server/server-detail-resolves.js
@@ -28,10 +28,9 @@ export const getData = ($stateParams: { id: string }) => {
 
 export default function serverDetailResolves($stateParams: { id: string }) {
   'ngInject';
-  const getObjectsOrNull = x => (x.objects.length ? x : null);
-  const getFlatObjOrNull = fp.flow(
-    highland.map(getObjectsOrNull),
-    fp.invokeMethod('flatten')([])
+  const getObjectsOrNull = x => (x.objects.length ? x.objects : null);
+  const getFlatObjOrNull = fp.flow(highland.map(getObjectsOrNull), x =>
+    x.flatten()
   );
 
   const jobMonitorStream = broadcaster(store.select('jobIndicators'));

--- a/test/spec/iml/command/wait-for-command-completion-service-test.js
+++ b/test/spec/iml/command/wait-for-command-completion-service-test.js
@@ -42,7 +42,7 @@ describe('wait-for-command-completion-service', () => {
     beforeEach(() => {
       responseWithCommands = [{}];
 
-      waitForCommandCompletion(false, responseWithCommands).each(spy);
+      waitForCommandCompletion(false)(responseWithCommands).each(spy);
     });
 
     it('should call get command stream', () => {
@@ -89,7 +89,7 @@ describe('wait-for-command-completion-service', () => {
     beforeEach(() => {
       responseWithCommands = [{}];
 
-      waitForCommandCompletion(true, responseWithCommands);
+      waitForCommandCompletion(true)(responseWithCommands);
     });
 
     it('should call openCommandModal', () => {

--- a/test/spec/iml/server/create-host-profiles-stream-test.js
+++ b/test/spec/iml/server/create-host-profiles-stream-test.js
@@ -286,14 +286,15 @@ describe('host profile then', () => {
   });
 
   describe('create host profiles', () => {
-    let profile, spy, waitForCommandCompletion;
+    let profile, spy, waitForCommandCompletion, waitForCommandCompletionInner;
 
     beforeEach(() => {
       streams = [];
 
       const mod = require('../../../../source/iml/server/create-host-profiles-stream.js');
 
-      waitForCommandCompletion = jest.fn(() => highland());
+      waitForCommandCompletionInner = jest.fn(() => highland());
+      waitForCommandCompletion = jest.fn(() => waitForCommandCompletionInner);
 
       const createHostProfiles = mod.createHostProfilesFactory(
         waitForCommandCompletion
@@ -362,7 +363,11 @@ describe('host profile then', () => {
 
       it('should pass in the commands to wait for command completion', () => {
         jest.runAllTimers();
-        expect(waitForCommandCompletion).toHaveBeenCalledOnceWith(false, [
+
+        expect.assertions(2);
+
+        expect(waitForCommandCompletion).toHaveBeenCalledOnceWith(false);
+        expect(waitForCommandCompletionInner).toHaveBeenCalledOnceWith([
           {
             command: 1
           }

--- a/test/spec/iml/server/select-server-profile-step-test.js
+++ b/test/spec/iml/server/select-server-profile-step-test.js
@@ -277,6 +277,7 @@ describe('select server profile', () => {
         createOrUpdateHostsStream,
         getHostProfiles,
         waitForCommandCompletion,
+        waitForCommandCompletionInner,
         result,
         response,
         spy;
@@ -467,7 +468,8 @@ describe('select server profile', () => {
 
         createOrUpdateHostsStream = jest.fn(() => highland([response]));
 
-        waitForCommandCompletion = jest.fn(val => highland([val]));
+        waitForCommandCompletionInner = jest.fn(() => highland([]));
+        waitForCommandCompletion = jest.fn(() => waitForCommandCompletionInner);
 
         getHostProfiles = jest.fn(() =>
           highland([
@@ -500,6 +502,8 @@ describe('select server profile', () => {
       });
 
       it('should pass commands to wait for command completion', () => {
+        expect.assertions(2);
+
         const commands = fp.flow(
           x => x.objects,
           fp.map(x => x.command_and_host),
@@ -507,8 +511,8 @@ describe('select server profile', () => {
           fp.filter(x => x)
         )(response);
 
-        expect(waitForCommandCompletion).toHaveBeenCalledOnceWith(
-          true,
+        expect(waitForCommandCompletion).toHaveBeenCalledOnceWith(true);
+        expect(waitForCommandCompletionInner).toHaveBeenCalledOnceWith(
           commands
         );
       });


### PR DESCRIPTION
Fixes #35.

waitForCommandCompletion was not updated to unary functions when currying was removed.

Signed-off-by: Joe Grund <joe.grund@intel.com>