### PR TITLE
Implement Popover using Inferno

### DIFF
--- a/source/iml/popover.js
+++ b/source/iml/popover.js
@@ -1,0 +1,85 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+import Component from 'inferno-component';
+
+type PopoverChildProps = {
+  children: React$Element<*>[]
+};
+
+export class PopoverContainer extends Component {
+  windowListener: ?Function;
+  state: { isOpen: boolean };
+  constructor(props: PopoverChildProps) {
+    super(props);
+    this.state = { isOpen: false };
+  }
+  windowHandler() {
+    const { isOpen: previousIsOpen } = this.state;
+    const isOpen = !previousIsOpen;
+
+    this.setState({ isOpen });
+
+    if (isOpen || !this.windowListener) return;
+
+    window.removeEventListener('click', this.windowListener, false);
+    this.windowListener = null;
+  }
+  handleClick() {
+    if (this.windowListener) return;
+
+    this.windowListener = this.windowHandler.bind(this);
+    window.addEventListener('click', this.windowListener);
+  }
+  render() {
+    const children = this.props.children.map(c => {
+      if (c.props.popoverButton)
+        return Inferno.cloneVNode(c, {
+          onClick: this.handleClick.bind(this)
+        });
+      else if (c.props.popover)
+        return Inferno.cloneVNode(c, {
+          visible: this.state.isOpen
+        });
+      else return c;
+    });
+
+    return (
+      <span style="position: relative;">
+        {children}
+      </span>
+    );
+  }
+}
+
+export const PopoverTitle = ({ children }: PopoverChildProps) =>
+  <h3 class="popover-title">
+    {children}
+  </h3>;
+
+export const PopoverContent = ({ children }: PopoverChildProps) =>
+  <div class="popover-content">
+    {children}
+  </div>;
+
+type PopoverProps = {
+  children?: React$Element<*>,
+  visible?: boolean,
+  direction: 'top' | 'bottom' | 'left' | 'right'
+};
+
+export const Popover = ({ children, visible, direction }: PopoverProps) => {
+  if (!visible) return;
+
+  return (
+    <div className={`fade popover ${direction} in`}>
+      <div class="arrow" />
+      {children}
+    </div>
+  );
+};

--- a/source/iml/popover.less
+++ b/source/iml/popover.less
@@ -1,0 +1,66 @@
+.popover-container {
+  position: relative;
+
+  &.popover-hover:hover .popover {
+    display: block;
+    opacity: .9;
+    max-width: 200px;
+
+    .popover-inner {
+      word-wrap: break-word;
+    }
+  }
+}
+
+.popover {
+  top: auto;
+  left: auto;
+  width: 200px;
+
+  &.xsmall {
+    width: 50px;
+  }
+
+  &.small {
+    width: 100px;
+  }
+
+  &.medium {
+    width: 150px;
+  }
+
+  &.large {
+    width: 200px;
+  }
+
+  &.right {
+    left: 100%;
+    bottom: 50%;
+    transform: translateY(50%);
+  }
+
+  &.left {
+    bottom: 50%;
+    transform: translate(-100%, 50%);
+  }
+
+  &.bottom {
+    transform: translateX(50%);
+    top: 100%;
+    right: 50%;
+  }
+
+  &.top {
+    transform: translate(50%, -100%);
+    top: 0;
+    right: 50%;
+  }
+}
+
+.popover {
+  display: none;
+
+  &.in {
+    display: block;
+  }
+}

--- a/test/dom/iml/__snapshots__/popover-test.js.snap
+++ b/test/dom/iml/__snapshots__/popover-test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Popover DOM testing Container should open and close when clicking the button 1`] = `"<span style=\\"position: relative;\\"><button popoverbutton=\\"true\\"></button><div class=\\"fade popover right in\\"><div class=\\"arrow\\"></div><div class=\\"popover-content\\">bar</div></div></span>"`;
+
+exports[`Popover DOM testing Container should open and close when clicking the button 2`] = `"<span style=\\"position: relative;\\"><button popoverbutton=\\"true\\"></button></span>"`;
+
+exports[`Popover DOM testing Container should render correctly 1`] = `"<span style=\\"position: relative;\\"><button popoverbutton=\\"true\\"></button></span>"`;
+
+exports[`Popover DOM testing should not render if not visible 1`] = `""`;
+
+exports[`Popover DOM testing should render correctly with a title 1`] = `"<div class=\\"fade popover bottom in\\"><div class=\\"arrow\\"></div><h3 class=\\"popover-title\\">Hi</h3><div class=\\"popover-content\\">Foo</div></div>"`;
+
+exports[`Popover DOM testing should render correctly without a title 1`] = `"<div class=\\"fade popover bottom in\\"><div class=\\"arrow\\"></div><div class=\\"popover-content\\">Foo</div></div>"`;
+
+exports[`Popover DOM testing should render sub-props correctly 1`] = `"<div class=\\"fade popover right in\\"><div class=\\"arrow\\"></div><h3 class=\\"popover-title\\">Hi</h3><div class=\\"popover-content\\">This is some content</div></div>"`;

--- a/test/dom/iml/popover-test.js
+++ b/test/dom/iml/popover-test.js
@@ -1,0 +1,109 @@
+// @flow
+
+import Inferno from 'inferno';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTitle,
+  PopoverContainer
+} from '../../../source/iml/popover';
+import { querySelector } from '../../../source/iml/dom-utils.js';
+
+describe('Popover DOM testing', () => {
+  let renderToSnapshot;
+
+  beforeEach(() => {
+    renderToSnapshot = child => {
+      const root = document.createElement('div');
+      Inferno.render(child, root);
+      return root.innerHTML;
+    };
+  });
+
+  it('should render correctly without a title', () => {
+    expect(
+      renderToSnapshot(
+        <Popover visible={true} direction="bottom">
+          <PopoverContent>Foo</PopoverContent>
+        </Popover>
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('should render correctly with a title', () => {
+    expect(
+      renderToSnapshot(
+        <Popover visible={true} direction="bottom">
+          <PopoverTitle>Hi</PopoverTitle>
+          <PopoverContent>Foo</PopoverContent>
+        </Popover>
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('should render sub-props correctly', () => {
+    const message = 'This is some content';
+
+    expect(
+      renderToSnapshot(
+        <Popover visible={true} direction="right">
+          <PopoverTitle>Hi</PopoverTitle>
+          <PopoverContent>
+            {message}
+          </PopoverContent>
+        </Popover>
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('should not render if not visible', () => {
+    expect(
+      renderToSnapshot(
+        <Popover visible={false} direction="right">
+          <PopoverContent>bar</PopoverContent>
+        </Popover>
+      )
+    ).toMatchSnapshot();
+  });
+
+  describe('Container', () => {
+    let root, vNode;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+
+      vNode = (
+        <PopoverContainer>
+          <button popoverButton={true} />
+          <Popover popover={true} direction="right">
+            <PopoverContent>bar</PopoverContent>
+          </Popover>
+        </PopoverContainer>
+      );
+
+      Inferno.render(vNode, root);
+
+      querySelector(document, 'body').appendChild(root);
+    });
+
+    afterEach(() => {
+      querySelector(document, 'body').removeChild(root);
+    });
+
+    it('should render correctly', () => {
+      expect(renderToSnapshot(vNode)).toMatchSnapshot();
+    });
+
+    it('should open and close when clicking the button', () => {
+      expect.assertions(2);
+
+      querySelector(root, 'button').click();
+
+      expect(root.innerHTML).toMatchSnapshot();
+
+      querySelector(root, 'button').click();
+
+      expect(root.innerHTML).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
As we move to using inferno, we need to
re-implement components.

Re-do the popover component in inferno.

In addition, add tests.

A follow-up patch will replace the existing popover.

Signed-off-by: Joe Grund <joe.grund@intel.com>