### PR TITLE
Using webpack with watch generates extra files that are not cleaned up.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-plugin-transform-remove-strict-mode": "0.0.2",
     "babel-preset-env": "^1.6.0",
     "bootstrap": "3.3.7",
+    "clean-webpack-plugin": "^0.1.16",
     "cross-env": "4.0.0",
     "css-loader": "^0.28.4",
     "d3": "3.5.17",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,11 +8,11 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const extractLess = new ExtractTextPlugin('[name].[contenthash].css');
 
-const pathsToClean = ['dist/*.*'];
+const pathsToClean = ['dist/*'];
 
 const cleanOptions = {
   root: __dirname,
-  verbose: true,
+  verbose: false,
   dry: false,
   watch: true
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,10 +2,20 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const extractLess = new ExtractTextPlugin('[name].[contenthash].css');
+
+const pathsToClean = ['dist/*.*'];
+
+const cleanOptions = {
+  root: __dirname,
+  verbose: true,
+  dry: false,
+  watch: true
+};
 
 const config = {
   devtool: 'source-map',
@@ -75,7 +85,8 @@ const config = {
     new webpack.optimize.ModuleConcatenationPlugin(),
     new HtmlWebpackPlugin({
       template: 'index.ejs'
-    })
+    }),
+    new CleanWebpackPlugin(pathsToClean, cleanOptions)
   ]
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1216,6 +1216,12 @@ clean-css@^3.0.1:
     commander "2.8.x"
     source-map "0.4.x"
 
+clean-webpack-plugin@^0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.16.tgz#422a8e150bf3d5abfd3d14bfacb070e80fb2e23f"
+  dependencies:
+    rimraf "~2.5.1"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -4282,6 +4288,12 @@ right-align@^0.1.1:
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
+
+rimraf@~2.5.1:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
     glob "^7.0.5"
 


### PR DESCRIPTION
Installing the library: clean-webpack-plugin

allows for the elimination of unwanted files during webpack builds.

 - Added the clean-webpack-plugin library
 - Modified the webpack.config.js file to specify what files to purge