### PR TITLE
Create WindowClickListener component

### DIFF
--- a/source/iml/alert-indicator/alert-indicator.js
+++ b/source/iml/alert-indicator/alert-indicator.js
@@ -7,6 +7,7 @@
 
 import Inferno from 'inferno';
 import Tooltip from '../tooltip.js';
+import WindowClickListener from '../window-click-listener.js';
 
 import { asViewer } from '../as-viewer/as-viewer';
 import {
@@ -40,37 +41,39 @@ const AlertIndicator = asViewer(
 
     return (
       <span class="record-state">
-        <PopoverContainer>
-          <span
-            class="icon-wrap tooltip-container tooltip-hover"
-            popoverButton={true}
-          >
-            <i
-              className={`fa activate-popover ${alerts.length > 0
-                ? 'fa-exclamation-circle'
-                : 'fa-check-circle'}`}
-            />
-            <Tooltip
-              size={alerts.length === 0 ? 'small' : 'medium'}
-              direction="top"
-              message={getMessage(alerts)}
-            />
-          </span>
-          {alerts.length
-            ? <Popover popover={true} direction="bottom">
-                <PopoverTitle>Alerts</PopoverTitle>
-                <PopoverContent>
-                  <ul>
-                    {alerts.map(x =>
-                      <li key={x.id}>
-                        {x.message}
-                      </li>
-                    )}
-                  </ul>
-                </PopoverContent>
-              </Popover>
-            : ''}
-        </PopoverContainer>
+        <WindowClickListener>
+          <PopoverContainer>
+            <span
+              class="icon-wrap tooltip-container tooltip-hover"
+              popoverButton={true}
+            >
+              <i
+                className={`fa activate-popover ${alerts.length > 0
+                  ? 'fa-exclamation-circle'
+                  : 'fa-check-circle'}`}
+              />
+              <Tooltip
+                size={alerts.length === 0 ? 'small' : 'medium'}
+                direction="top"
+                message={getMessage(alerts)}
+              />
+            </span>
+            {alerts.length
+              ? <Popover popover={true} direction="bottom">
+                  <PopoverTitle>Alerts</PopoverTitle>
+                  <PopoverContent>
+                    <ul>
+                      {alerts.map(x =>
+                        <li key={x.id}>
+                          {x.message}
+                        </li>
+                      )}
+                    </ul>
+                  </PopoverContent>
+                </Popover>
+              : ''}
+          </PopoverContainer>
+        </WindowClickListener>
 
         {size === 'medium'
           ? <span style="padding-left:10px;" class="state-label">

--- a/source/iml/popover.js
+++ b/source/iml/popover.js
@@ -13,39 +13,16 @@ type PopoverChildProps = {
 };
 
 export class PopoverContainer extends Component {
-  windowListener: ?Function;
-  state: { isOpen: boolean };
-  constructor(props: PopoverChildProps) {
-    super(props);
-    this.state = { isOpen: false };
-  }
-  windowHandler() {
-    const { isOpen: previousIsOpen } = this.state;
-    const isOpen = !previousIsOpen;
-
-    this.setState({ isOpen });
-
-    if (isOpen || !this.windowListener) return;
-
-    window.removeEventListener('click', this.windowListener, false);
-    this.windowListener = null;
-  }
-  handleClick() {
-    if (this.windowListener) return;
-
-    this.windowListener = this.windowHandler.bind(this);
-    window.addEventListener('click', this.windowListener);
-  }
   render() {
     const children = this.props.children.map(c => {
       if (!c.props) return c;
       else if (c.props.popoverButton)
         return Inferno.cloneVNode(c, {
-          onClick: this.handleClick.bind(this)
+          onClick: this.props.toggleOpen
         });
       else if (c.props.popover)
         return Inferno.cloneVNode(c, {
-          visible: this.state.isOpen
+          visible: this.props.isOpen
         });
       else return c;
     });

--- a/source/iml/window-click-listener.js
+++ b/source/iml/window-click-listener.js
@@ -1,0 +1,55 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+import Component from 'inferno-component';
+
+export default class WindowClickListener extends Component {
+  windowListener: ?Function;
+  state: { isOpen: boolean } = { isOpen: false };
+  props: {
+    children: React$Element<*>
+  };
+  componentWillUnmount() {
+    if (this.windowListener)
+      window.removeEventListener('click', this.windowListener, false);
+  }
+  windowHandler() {
+    const { isOpen: previousIsOpen } = this.state;
+    const isOpen = !previousIsOpen;
+
+    this.setState({ isOpen });
+
+    if (isOpen || !this.windowListener) return;
+
+    window.removeEventListener('click', this.windowListener, false);
+    this.windowListener = null;
+  }
+  toggleOpen() {
+    if (this.windowListener) return;
+
+    this.windowListener = this.windowHandler.bind(this);
+    window.addEventListener('click', this.windowListener);
+  }
+  render() {
+    if (Array.isArray(this.props.children))
+      throw new Error(
+        `WindowClickListener expects a single child, got ${this.props.children
+          .length} children`
+      );
+
+    if (!this.props.children)
+      throw new Error(
+        `WindowClickListener expects a single child, got 0 children`
+      );
+
+    return Inferno.cloneVNode(this.props.children, {
+      isOpen: this.state.isOpen,
+      toggleOpen: this.toggleOpen.bind(this)
+    });
+  }
+}

--- a/test/dom/iml/__snapshots__/window-click-listener-test.js.snap
+++ b/test/dom/iml/__snapshots__/window-click-listener-test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WindowClickListener DOM testing should close when an adjacent el is clicked 1`] = `"<span class=\\"clicker\\">closed</span>"`;
+
+exports[`WindowClickListener DOM testing should close when clicked twice 1`] = `"<span class=\\"clicker\\">closed</span>"`;
+
+exports[`WindowClickListener DOM testing should open when clicked 1`] = `"<span class=\\"clicker\\">open</span>"`;
+
+exports[`WindowClickListener DOM testing should render the child 1`] = `"<span class=\\"clicker\\">closed</span>"`;

--- a/test/dom/iml/alert-indicator/alert-indicator-test.js
+++ b/test/dom/iml/alert-indicator/alert-indicator-test.js
@@ -2,6 +2,7 @@ import highland from 'highland';
 import broadcast from '../../../../source/iml/broadcaster.js';
 import Inferno from 'inferno';
 import AlertIndicator from '../../../../source/iml/alert-indicator/alert-indicator.js';
+import { renderToSnapshot } from '../../../test-utils.js';
 
 describe('AlertIndicator DOM testing', () => {
   let alertStream,
@@ -15,15 +16,7 @@ describe('AlertIndicator DOM testing', () => {
     alerts,
     tooltip;
 
-  let renderToSnapshot;
-
   beforeEach(() => {
-    renderToSnapshot = child => {
-      const root = document.createElement('div');
-      Inferno.render(child, root);
-      return root.innerHTML;
-    };
-
     stream = highland();
 
     alertStream = broadcast(stream);

--- a/test/dom/iml/popover-test.js
+++ b/test/dom/iml/popover-test.js
@@ -7,19 +7,11 @@ import {
   PopoverTitle,
   PopoverContainer
 } from '../../../source/iml/popover';
+import WindowClickListener from '../../../source/iml/window-click-listener.js';
+import { renderToSnapshot } from '../../test-utils.js';
 import { querySelector } from '../../../source/iml/dom-utils.js';
 
 describe('Popover DOM testing', () => {
-  let renderToSnapshot;
-
-  beforeEach(() => {
-    renderToSnapshot = child => {
-      const root = document.createElement('div');
-      Inferno.render(child, root);
-      return root.innerHTML;
-    };
-  });
-
   it('should render correctly without a title', () => {
     expect(
       renderToSnapshot(
@@ -73,12 +65,14 @@ describe('Popover DOM testing', () => {
       root = document.createElement('div');
 
       vNode = (
-        <PopoverContainer>
-          <button popoverButton={true} />
-          <Popover popover={true} direction="right">
-            <PopoverContent>bar</PopoverContent>
-          </Popover>
-        </PopoverContainer>
+        <WindowClickListener>
+          <PopoverContainer>
+            <button popoverButton={true} />
+            <Popover popover={true} direction="right">
+              <PopoverContent>bar</PopoverContent>
+            </Popover>
+          </PopoverContainer>
+        </WindowClickListener>
       );
 
       Inferno.render(vNode, root);

--- a/test/dom/iml/window-click-listener-test.js
+++ b/test/dom/iml/window-click-listener-test.js
@@ -1,0 +1,63 @@
+// @flow
+
+import WindowClickListener from '../../../source/iml/window-click-listener.js';
+import Inferno from 'inferno';
+import { renderToSnapshot } from '../../test-utils.js';
+import { querySelector } from '../../../source/iml/dom-utils.js';
+
+describe('WindowClickListener DOM testing', () => {
+  let root, component, sibling;
+
+  beforeEach(() => {
+    const MockComponent = (props: {
+      isOpen?: boolean,
+      toggleOpen?: Function
+    }) => {
+      return (
+        <span class="clicker" onClick={props.toggleOpen}>
+          {props.isOpen ? 'open' : 'closed'}
+        </span>
+      );
+    };
+
+    root = document.createElement('div');
+    sibling = document.createElement('div');
+    querySelector(document, 'body').appendChild(root);
+    querySelector(document, 'body').appendChild(sibling);
+    component = (
+      <WindowClickListener>
+        <MockComponent />
+      </WindowClickListener>
+    );
+
+    Inferno.render(component, root);
+  });
+
+  afterEach(() => {
+    querySelector(document, 'body').removeChild(root);
+    querySelector(document, 'body').removeChild(sibling);
+  });
+
+  it('should render the child', () => {
+    expect(renderToSnapshot(component)).toMatchSnapshot();
+  });
+
+  it('should open when clicked', () => {
+    querySelector(root, '.clicker').click();
+
+    expect(root.innerHTML).toMatchSnapshot();
+  });
+
+  it('should close when clicked twice', () => {
+    const clicker = querySelector(root, '.clicker');
+    clicker.click();
+    clicker.click();
+    expect(root.innerHTML).toMatchSnapshot();
+  });
+
+  it('should close when an adjacent el is clicked', () => {
+    querySelector(root, '.clicker').click();
+    sibling.click();
+    expect(root.innerHTML).toMatchSnapshot();
+  });
+});

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,4 +1,5 @@
 import * as fp from '@iml/fp';
+import Inferno from 'inferno';
 
 export const extendWithConstructor = (constructor, obj) => {
   const scope = Object.create({}, {});
@@ -25,3 +26,9 @@ export const convertNvDates = s =>
       });
     })
   );
+
+export const renderToSnapshot = child => {
+  const root = document.createElement('div');
+  Inferno.render(child, root);
+  return root.innerHTML;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,9 +2116,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.50.0:
-  version "0.50.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.50.0.tgz#d4cdb2430dee1a3599f0eb6fe551146e3027256a"
+flow-bin@^0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.51.0.tgz#97a3c511a17caa25d8fad58fc17aaabcb86319fe"
 
 font-awesome-webpack@^0.0.5-beta.2:
   version "0.0.5-beta.2"


### PR DESCRIPTION
We have a pattern (that seems to be shared by bootstrap components) where we
need to listen to a click on the window
to trigger closing a component.

As an example, consider a dropdown.

Clicking the dropdown button should open it.
Clicking anywhere after the dropdown is open
should close it.

This work is needed as part of #31.

Signed-off-by: Joe Grund <joe.grund@intel.com>