### PR TITLE
Create pagination components

### DIFF
--- a/source/iml/dropdown-component.js
+++ b/source/iml/dropdown-component.js
@@ -1,0 +1,28 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+
+type Props = {
+  isOpen?: boolean,
+  toggleOpen?: Function,
+  children: React$Element<*>[]
+};
+
+export default (props: Props) => {
+  if (props.children.length !== 2)
+    throw new Error('DropdownContainer expects two children');
+
+  const [button, ul] = props.children;
+
+  return (
+    <div className={`btn-group dropdown ${props.isOpen ? 'open' : ''}`}>
+      {Inferno.cloneVNode(button, { onClick: props.toggleOpen })}
+      {ul}
+    </div>
+  );
+};

--- a/source/iml/pagination-components.js
+++ b/source/iml/pagination-components.js
@@ -1,0 +1,123 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno, { linkEvent } from 'inferno';
+import WindowClickListener from './window-click-listener.js';
+import DropdownContainer from './dropdown-component.js';
+
+type EntriesProps = {
+  entries: number,
+  setEntries: Function
+};
+
+export const EntriesDropdown = (props: EntriesProps) =>
+  <WindowClickListener>
+    <DropdownContainer>
+      <button
+        type="button"
+        class="btn btn-info btn-sm dropdown-toggle"
+        aria-haspopup="true"
+        aria-expanded="false"
+      >
+        Entries: {props.entries} <span class="caret" />
+      </button>
+      <ul role="menu" class="dropdown-menu">
+        {[10, 25, 50, 100].map(x =>
+          <li>
+            <a onClick={linkEvent(x, props.setEntries)}>
+              {x}
+            </a>
+          </li>
+        )}
+      </ul>
+    </DropdownContainer>
+  </WindowClickListener>;
+
+type Meta = {
+  limit: number,
+  next: ?string,
+  offset: number,
+  previous: ?string,
+  total_count: number
+};
+
+type PerPageProps = {
+  meta: Meta
+};
+
+export const TableInfo = ({ meta }: PerPageProps) =>
+  <span>
+    showing {meta.offset + 1}-{Math.min(
+      meta.offset + meta.limit,
+      meta.total_count
+    )}{' '}
+    of {meta.total_count}
+  </span>;
+
+const computePage = ({ limit, offset }) =>
+  limit === 0 ? 1 : Math.floor(offset / limit + 1);
+
+const computePages = ({ limit, total_count: totalCount }) =>
+  limit === 0 ? 1 : Math.ceil(totalCount / limit);
+
+const MAX_SIZE = 5;
+
+function getPages(page: number, pages: number): number[] {
+  let startPage = 1;
+  let endPage = pages;
+
+  if (pages > MAX_SIZE) {
+    startPage = Math.max(page - Math.floor(MAX_SIZE / 2), 1);
+    endPage = startPage + MAX_SIZE - 1;
+
+    if (endPage > pages) {
+      endPage = pages;
+      startPage = endPage - MAX_SIZE + 1;
+    }
+  }
+
+  const xs = [];
+  for (let i = startPage; i <= endPage; i++) xs.push(i);
+  return xs;
+}
+
+const computeOffset = (page, limit) => (page - 1) * limit;
+
+type PagerProps = {
+  meta: Meta,
+  setOffset: Function
+};
+
+export const Pager = ({ meta, setOffset }: PagerProps) => {
+  const pages = computePages(meta);
+
+  if (pages === 1) return;
+
+  const page = computePage(meta);
+
+  return (
+    <ul class="pagination">
+      <li className={`pagination-prev ${page === 1 ? 'disabled' : ''}`}>
+        <a onClick={linkEvent(computeOffset(page - 1, meta.limit), setOffset)}>
+          ‹
+        </a>
+      </li>
+      {getPages(page, pages).map(x =>
+        <li className={`pagination-page ${page === x ? 'active' : ''}`}>
+          <a onClick={linkEvent(computeOffset(x, meta.limit), setOffset)}>
+            {x}
+          </a>
+        </li>
+      )}
+      <li class={`pagination-next ${page === pages ? 'disabled' : ''}`}>
+        <a onClick={linkEvent(computeOffset(page + 1, meta.limit), setOffset)}>
+          ›
+        </a>
+      </li>
+    </ul>
+  );
+};

--- a/source/styles/main.less
+++ b/source/styles/main.less
@@ -36,15 +36,15 @@ a:hover {
 
 .page-header {
   margin-top: 0;
-  color: #FFFFFF;
+  color: #ffffff;
   padding: 15px 20px;
-  background-color: #0067B4;
-  border-bottom: 1px solid darken(#0067B4, 10%);
+  background-color: #0067b4;
+  border-bottom: 1px solid darken(#0067b4, 10%);
 }
 
 .section-header {
   margin-top: 50px;
-  color: #0067B4;
+  color: #0067b4;
 }
 
 .section-top-margin {
@@ -186,13 +186,21 @@ button.close:focus {
 }
 
 @keyframes fadeIn {
-  0% {opacity: 0}
-  100% {opacity: 1}
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 @keyframes fadeOut {
-  0% {opacity: 1}
-  100% {opacity: 0}
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 ui-loader-view {
@@ -233,5 +241,11 @@ ui-loader-view {
         transition: none;
       }
     }
+  }
+}
+
+.pagination {
+  li.disabled > a {
+    pointer-events: none;
   }
 }

--- a/test/dom/iml/__snapshots__/dropdown-component-test.js.snap
+++ b/test/dom/iml/__snapshots__/dropdown-component-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropdown DOM Tests should respond to isOpen 1`] = `"<div class=\\"btn-group dropdown open\\"><button></button><ul></ul></div>"`;

--- a/test/dom/iml/__snapshots__/pagination-components-test.js.snap
+++ b/test/dom/iml/__snapshots__/pagination-components-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EntriesDropdown DOM testing clicking should open when clicked 1`] = `"<div class=\\"btn-group dropdown open\\"><button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"btn btn-info btn-sm dropdown-toggle\\">Entries: 10 <span class=\\"caret\\"></span></button><ul role=\\"menu\\" class=\\"dropdown-menu\\"><li><a>10</a></li><li><a>25</a></li><li><a>50</a></li><li><a>100</a></li></ul></div>"`;
+
+exports[`EntriesDropdown DOM testing should render entries as expected 1`] = `"<div class=\\"btn-group dropdown \\"><button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"btn btn-info btn-sm dropdown-toggle\\">Entries: 10 <span class=\\"caret\\"></span></button><ul role=\\"menu\\" class=\\"dropdown-menu\\"><li><a>10</a></li><li><a>25</a></li><li><a>50</a></li><li><a>100</a></li></ul></div>"`;
+
+exports[`Pager DOM testing should disable the next button if on the last page 1`] = `"<ul class=\\"pagination\\"><li class=\\"pagination-prev \\"><a>‹</a></li><li class=\\"pagination-page \\"><a>1</a></li><li class=\\"pagination-page \\"><a>2</a></li><li class=\\"pagination-page \\"><a>3</a></li><li class=\\"pagination-page active\\"><a>4</a></li><li class=\\"pagination-next disabled\\"><a>›</a></li></ul>"`;
+
+exports[`Pager DOM testing should disable the previous button if on the first page 1`] = `"<ul class=\\"pagination\\"><li class=\\"pagination-prev disabled\\"><a>‹</a></li><li class=\\"pagination-page active\\"><a>1</a></li><li class=\\"pagination-page \\"><a>2</a></li><li class=\\"pagination-page \\"><a>3</a></li><li class=\\"pagination-page \\"><a>4</a></li><li class=\\"pagination-next \\"><a>›</a></li></ul>"`;
+
+exports[`Pager DOM testing should render as expected 1`] = `"<ul class=\\"pagination\\"><li class=\\"pagination-prev \\"><a>‹</a></li><li class=\\"pagination-page \\"><a>1</a></li><li class=\\"pagination-page active\\"><a>2</a></li><li class=\\"pagination-page \\"><a>3</a></li><li class=\\"pagination-page \\"><a>4</a></li><li class=\\"pagination-next \\"><a>›</a></li></ul>"`;
+
+exports[`Pager DOM testing should render nothing if there is a single page 1`] = `""`;
+
+exports[`Pager DOM testing should reset pages if on the trailing edge 1`] = `"<ul class=\\"pagination\\"><li class=\\"pagination-prev \\"><a>‹</a></li><li class=\\"pagination-page \\"><a>4</a></li><li class=\\"pagination-page \\"><a>5</a></li><li class=\\"pagination-page \\"><a>6</a></li><li class=\\"pagination-page \\"><a>7</a></li><li class=\\"pagination-page active\\"><a>8</a></li><li class=\\"pagination-next disabled\\"><a>›</a></li></ul>"`;
+
+exports[`TableInfo DOM testing should render as expected 1`] = `"<span>showing 11-20 of 100</span>"`;

--- a/test/dom/iml/dropdown-component-test.js
+++ b/test/dom/iml/dropdown-component-test.js
@@ -1,0 +1,55 @@
+// @flow
+import Inferno from 'inferno';
+import Dropdown from '../../../source/iml/dropdown-component.js';
+import { renderToSnapshot } from '../../test-utils.js';
+import { querySelector } from '../../../source/iml/dom-utils.js';
+
+describe('Dropdown DOM Tests', () => {
+  let root, clickHandler;
+
+  beforeEach(() => {
+    root = document.createElement('div');
+    querySelector(document, 'body').appendChild(root);
+
+    clickHandler = jest.fn();
+  });
+
+  afterEach(() => {
+    querySelector(document, 'body').removeChild(root);
+  });
+
+  it('should throw if two children nodes are not passed', () => {
+    expect(() =>
+      Inferno.render(
+        <Dropdown isOpen={false} toggleOpen={clickHandler}>
+          <div />
+        </Dropdown>,
+        root
+      )
+    ).toThrow();
+  });
+
+  it('should open on click', () => {
+    Inferno.render(
+      <Dropdown isOpen={false} toggleOpen={clickHandler}>
+        <button />
+        <ul />
+      </Dropdown>,
+      root
+    );
+
+    querySelector(root, 'button').click();
+    expect(clickHandler).toHaveBeenCalledOnceWith(expect.any(Object));
+  });
+
+  it('should respond to isOpen', () => {
+    expect(
+      renderToSnapshot(
+        <Dropdown isOpen={true} toggleOpen={clickHandler}>
+          <button />
+          <ul />
+        </Dropdown>
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/test/dom/iml/pagination-components-test.js
+++ b/test/dom/iml/pagination-components-test.js
@@ -1,0 +1,189 @@
+// @flow
+import Inferno from 'inferno';
+import {
+  Pager,
+  EntriesDropdown,
+  TableInfo
+} from '../../../source/iml/pagination-components.js';
+import { renderToSnapshot } from '../../test-utils.js';
+import { querySelector } from '../../../source/iml/dom-utils.js';
+
+type Meta = {
+  limit: number,
+  next: ?string,
+  offset: number,
+  previous: ?string,
+  total_count: number
+};
+
+describe('EntriesDropdown DOM testing', () => {
+  let clickHandler, vnode;
+
+  beforeEach(() => {
+    clickHandler = jest.fn();
+    vnode = <EntriesDropdown entries={10} setEntries={clickHandler} />;
+  });
+
+  it('should render entries as expected', () => {
+    expect(renderToSnapshot(vnode)).toMatchSnapshot();
+  });
+
+  describe('clicking', () => {
+    let root;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      querySelector(document, 'body').appendChild(root);
+      Inferno.render(vnode, root);
+    });
+
+    afterEach(() => {
+      querySelector(document, 'body').removeChild(root);
+    });
+
+    it('should open when clicked', () => {
+      querySelector(root, 'button').click();
+
+      expect(root.innerHTML).toMatchSnapshot();
+    });
+
+    it('should call handler when entry is clicked', () => {
+      querySelector(root, 'button').click();
+      root.querySelectorAll('a')[1].click();
+
+      expect(clickHandler).toHaveBeenCalledOnceWith(25, expect.any(Object));
+    });
+  });
+});
+
+describe('TableInfo DOM testing', () => {
+  let meta: Meta;
+
+  beforeEach(() => {
+    meta = {
+      limit: 10,
+      total_count: 100,
+      offset: 10,
+      previous: null,
+      next: null
+    };
+  });
+
+  it('should render as expected', () => {
+    expect(renderToSnapshot(<TableInfo meta={meta} />)).toMatchSnapshot();
+  });
+});
+
+describe('Pager DOM testing', () => {
+  let meta: Meta, clickHandler;
+
+  beforeEach(() => {
+    meta = {
+      limit: 10,
+      total_count: 100,
+      offset: 10,
+      previous: null,
+      next: null
+    };
+
+    clickHandler = jest.fn();
+  });
+
+  it('should render nothing if there is a single page', () => {
+    meta = {
+      limit: 10,
+      total_count: 10,
+      offset: 0,
+      previous: null,
+      next: null
+    };
+    expect(
+      renderToSnapshot(<Pager meta={meta} setOffset={clickHandler} />)
+    ).toMatchSnapshot();
+  });
+
+  it('should render as expected', () => {
+    const newMeta = {
+      ...meta,
+      limit: 25,
+      total_count: 100,
+      offset: 49
+    };
+
+    expect(
+      renderToSnapshot(<Pager meta={newMeta} setOffset={clickHandler} />)
+    ).toMatchSnapshot();
+  });
+
+  it('should reset pages if on the trailing edge', () => {
+    const newMeta = {
+      ...meta,
+      limit: 25,
+      total_count: 200,
+      offset: 199
+    };
+
+    expect(
+      renderToSnapshot(<Pager meta={newMeta} setOffset={clickHandler} />)
+    ).toMatchSnapshot();
+  });
+
+  it('should disable the previous button if on the first page', () => {
+    const newMeta = {
+      ...meta,
+      limit: 25,
+      total_count: 100,
+      offset: 0
+    };
+
+    expect(
+      renderToSnapshot(<Pager meta={newMeta} setOffset={clickHandler} />)
+    ).toMatchSnapshot();
+  });
+
+  it('should disable the next button if on the last page', () => {
+    const newMeta = {
+      ...meta,
+      limit: 25,
+      total_count: 100,
+      offset: 95
+    };
+
+    expect(
+      renderToSnapshot(<Pager meta={newMeta} setOffset={clickHandler} />)
+    ).toMatchSnapshot();
+  });
+
+  describe('click handling', () => {
+    let root;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      querySelector(document, 'body').appendChild(root);
+
+      Inferno.render(<Pager meta={meta} setOffset={clickHandler} />, root);
+    });
+
+    afterEach(() => {
+      querySelector(document, 'body').removeChild(root);
+    });
+
+    it('should go to the previous page when clicking previous', () => {
+      querySelector(root, '.pagination-prev a').click();
+
+      expect(clickHandler).toHaveBeenCalledOnceWith(0, expect.any(Object));
+    });
+
+    it('should go to the next page when clicking next', () => {
+      querySelector(root, '.pagination-next a').click();
+
+      expect(clickHandler).toHaveBeenCalledOnceWith(20, expect.any(Object));
+    });
+
+    it('should go to the clicked page', () => {
+      querySelector(root, '.pagination-page a').click();
+
+      expect(clickHandler).toHaveBeenCalledOnceWith(0, expect.any(Object));
+    });
+  });
+});

--- a/test/dom/iml/window-click-listener-test.js
+++ b/test/dom/iml/window-click-listener-test.js
@@ -29,8 +29,6 @@ describe('WindowClickListener DOM testing', () => {
         <MockComponent />
       </WindowClickListener>
     );
-
-    Inferno.render(component, root);
   });
 
   afterEach(() => {
@@ -38,17 +36,37 @@ describe('WindowClickListener DOM testing', () => {
     querySelector(document, 'body').removeChild(sibling);
   });
 
+  it('should throw on more than one child', () => {
+    expect(() =>
+      Inferno.render(
+        <WindowClickListener>
+          <div />
+          <div />
+        </WindowClickListener>,
+        root
+      )
+    ).toThrow();
+  });
+
+  it('should throw on zero children', () => {
+    // $FlowFixMe: This is passing wrong types on purpose
+    expect(() => Inferno.render(<WindowClickListener />, root)).toThrow();
+  });
+
   it('should render the child', () => {
+    Inferno.render(component, root);
     expect(renderToSnapshot(component)).toMatchSnapshot();
   });
 
   it('should open when clicked', () => {
+    Inferno.render(component, root);
     querySelector(root, '.clicker').click();
 
     expect(root.innerHTML).toMatchSnapshot();
   });
 
   it('should close when clicked twice', () => {
+    Inferno.render(component, root);
     const clicker = querySelector(root, '.clicker');
     clicker.click();
     clicker.click();
@@ -56,6 +74,7 @@ describe('WindowClickListener DOM testing', () => {
   });
 
   it('should close when an adjacent el is clicked', () => {
+    Inferno.render(component, root);
     querySelector(root, '.clicker').click();
     sibling.click();
     expect(root.innerHTML).toMatchSnapshot();


### PR DESCRIPTION
Create some pagination components in
Inferno that are reusable across
the GUI.

In particular, create components
that do pagination, number or entry selection,
and listing table info.

We can use the meta field of the
API response to glean the needed info.

This is needed as part of #31 

Signed-off-by: Joe Grund <joe.grund@intel.com>