### PR TITLE
Add filterSame transform.

### DIFF
--- a/source/iml/api-transforms.js
+++ b/source/iml/api-transforms.js
@@ -29,3 +29,16 @@ export const rememberValue = <A, B, C: HighlandStreamT<B> | B[]>(
 
   return in$.tap(x => (v = x)).flatMap(mapFn).map(() => v).otherwise(() => [v]);
 };
+
+export const filterSame = <A, B>(fn: B => A) => {
+  let last: ?A;
+
+  return (x: B) => {
+    const current = fn(x);
+    if (last === current) return false;
+
+    last = current;
+
+    return true;
+  };
+};

--- a/test/spec/iml/api-transforms-test.js
+++ b/test/spec/iml/api-transforms-test.js
@@ -4,7 +4,8 @@ import { of } from '@iml/maybe';
 import {
   addCurrentPage,
   rememberValue,
-  matchById
+  matchById,
+  filterSame
 } from '../../../source/iml/api-transforms.js';
 
 describe('api transforms', () => {
@@ -104,5 +105,16 @@ describe('match by id', () => {
         { id: 10, name: 'c' }
       ])
     ).toEqual(of({ id: 7, name: 'b' }));
+  });
+});
+
+describe('filterSame', () => {
+  it('should return bool on change / no change', () => {
+    expect.assertions(3);
+    const filter = filterSame(x => x.prop);
+
+    expect(filter({ prop: 'foo' })).toBe(true);
+    expect(filter({ prop: 'foo' })).toBe(false);
+    expect(filter({ prop: 'bar' })).toBe(true);
   });
 });


### PR DESCRIPTION
Add a `filterSame` transform.

It will take a value and only return true when
the previous and current value are different
by reference.

This is useful for filtering immutable values.

This is needed for #31 

Signed-off-by: Joe Grund <joe.grund@intel.com>