### PR TITLE
Implement Chart components for inferno.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "flow": "flow",
     "cover": "jest --coverage"
   },
-  "pre-commit": ["flow", "eslint", "test"],
+  "pre-commit": [
+    "flow",
+    "eslint",
+    "test"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/intel-hpdd/GUI.git"
@@ -20,7 +24,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@iml/debounce": "1.0.1",
+    "@iml/debounce": "^1.0.2",
     "@iml/deep-freeze": "2.0.2",
     "@iml/extract-api": "1.0.4",
     "@iml/flat-map-changes": "1.0.3",
@@ -60,7 +64,7 @@
     "css-loader": "^0.28.4",
     "d3": "3.5.17",
     "del": "2.2.2",
-    "eslint": "^4.4.0",
+    "eslint": "^4.4.1",
     "eslint-config-prettier": "^2.3.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-prettier": "^2.1.2",

--- a/source/iml/charting/area.js
+++ b/source/iml/charting/area.js
@@ -1,0 +1,40 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+import Component from 'inferno-component';
+import d3 from 'd3';
+import { flow } from '@iml/fp';
+
+let counter = 0;
+
+export default class Area extends Component {
+  count: number;
+  componentWillMount() {
+    this.count = counter += 1;
+
+    this.props.chartingGroup
+      .append('g')
+      .append('svg:path')
+      .classed(`area area${this.count}`, true);
+  }
+  render() {
+    const area = d3.svg
+      .area()
+      .interpolate('cardinal')
+      .x(flow(this.props.xValue, this.props.xScale))
+      .y0(this.props.yScale.range()[0])
+      .y1(flow(this.props.y1Value, this.props.yScale));
+
+    this.props.chartingGroup
+      .select(`.area${this.count}`)
+      .attr('stroke', this.props.color)
+      .attr('fill', this.props.color)
+      .attr('fill-opacity', '0.2')
+      .attr('d', area);
+  }
+}

--- a/source/iml/charting/axis.js
+++ b/source/iml/charting/axis.js
@@ -1,0 +1,60 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+import Component from 'inferno-component';
+import d3 from 'd3';
+
+type AxisProps = {
+  chartingGroup?: Object,
+  type: 'x' | 'y',
+  xScale?: Object,
+  yScale?: Object,
+  dimensions?: {
+    usableHeight: number,
+    usableWidth: number
+  }
+};
+
+export default class Axis extends Component {
+  props: AxisProps;
+  axis: Object;
+  componentWillMount() {
+    if (this.props.dimensions == null)
+      throw new Error('props.dimensions missing.');
+    if (this.props.chartingGroup == null)
+      throw new Error('props.chartingGroup missing.');
+
+    const { dimensions, chartingGroup } = this.props;
+
+    this.axis = d3.svg
+      .axis()
+      .orient(this.props.type === 'x' ? 'bottom' : 'left')
+      .scale(this.props.type === 'x' ? this.props.xScale : this.props.yScale);
+
+    chartingGroup
+      .append('g')
+      .classed(`axis ${this.props.type}-axis`, true)
+      .call(
+        x =>
+          this.props.type === 'x'
+            ? x.attr(
+                'transform',
+                `translate(0,${dimensions.usableHeight - 20})`
+              )
+            : x
+      );
+  }
+  componentWillUnmount() {
+    if (this.props.chartingGroup == null) return;
+    this.props.chartingGroup.select(`.${this.props.type}-axis`).remove();
+  }
+  render() {
+    if (this.props.chartingGroup == null) return;
+    this.props.chartingGroup.select(`.${this.props.type}-axis`).call(this.axis);
+  }
+}

--- a/source/iml/charting/chart.js
+++ b/source/iml/charting/chart.js
@@ -1,0 +1,108 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+import Component from 'inferno-component';
+import debounce from '@iml/debounce';
+import d3 from 'd3';
+import global from '../global.js';
+
+import { cloneChildren } from '../inferno-utils.js';
+
+type ChartProps<P> = {
+  margins: {
+    top: number,
+    right: number,
+    bottom: number,
+    left: number
+  },
+  points: P[],
+  children: React$Element<*>
+};
+
+type ChartState = {
+  svg?: HTMLElement,
+  dimensions?: {
+    usableWidth: number,
+    usableHeight: number
+  }
+};
+
+export default class Chart extends Component {
+  state: ChartState = {};
+  props: ChartProps<*>;
+  debounced: Function;
+  componentWillMount() {
+    const onResize = () => {
+      if (!this.state.svg) return;
+
+      const rect = this.state.svg.getBoundingClientRect();
+
+      this.setState({
+        ...this.state,
+        dimensions: this.getDimensions(rect)
+      });
+    };
+
+    this.debounced = debounce(onResize, 100);
+
+    global.addEventListener('resize', this.debounced);
+  }
+  componentWillUnmount() {
+    global.removeEventListener('resize', this.debounced, false);
+  }
+  getDimensions({ width, height }: { width: number, height: number }) {
+    return {
+      usableWidth: width - this.props.margins.left - this.props.margins.right,
+      usableHeight: height - this.props.margins.top - this.props.margins.bottom
+    };
+  }
+  gotComponent(svg: HTMLElement) {
+    if (this.state.svg != null) return;
+
+    const rect = svg.getBoundingClientRect();
+
+    this.setState({
+      svg,
+      dimensions: this.getDimensions(rect)
+    });
+  }
+  render() {
+    return (
+      <svg
+        ref={el => {
+          this.gotComponent(el);
+        }}
+        class="charting"
+        style={{ width: '100%', height: '100%' }}
+      >
+        <g
+          class="charting-group"
+          transform={`translate(${this.props.margins.left},${this.props.margins
+            .top})`}
+        >
+          {(() => {
+            if (this.state.svg) {
+              const svg = d3.select(this.state.svg).datum(this.props.points);
+              const chartingGroup = svg.select('.charting-group');
+
+              return cloneChildren(this.props.children, () => ({
+                points: this.props.points,
+                margins: this.props.margins,
+                dimensions: this.state.dimensions,
+                chartingGroup,
+                svg
+              }));
+            } else {
+              return null;
+            }
+          })()}
+        </g>
+      </svg>
+    );
+  }
+}

--- a/source/iml/charting/legend.js
+++ b/source/iml/charting/legend.js
@@ -1,0 +1,38 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import Inferno from 'inferno';
+import Component from 'inferno-component';
+
+import { getLegendFactory } from '../charting/types/legend/get-legend.js';
+
+const getLegend = getLegendFactory();
+
+export default class Legend extends Component {
+  legend: Object;
+  componentWillMount() {
+    // $FlowFixMe: Flow isn't smart enough disambiguate return types
+    this.legend = getLegend().showLabels(true).height(20).padding(20);
+
+    this.props.svg
+      .append('g')
+      .classed(`legend`, true)
+      .call(
+        x =>
+          this.props.transform != null
+            ? x.attr('transform', this.props.transform)
+            : x
+      );
+  }
+  render() {
+    this.legend
+      .colors(this.props.colors)
+      .width(this.props.dimensions.usableWidth);
+
+    this.props.svg.select('.legend').call(this.legend);
+  }
+}

--- a/source/iml/charting/line.js
+++ b/source/iml/charting/line.js
@@ -1,0 +1,45 @@
+// @flow
+
+//
+// Copyright (c) 2017 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+import getLine from '../charting/types/line/get-line.js';
+import Inferno from 'inferno';
+import Component from 'inferno-component';
+
+type LineProps = {
+  chartingGroup?: Object,
+  interpolate?: string,
+  xScale?: Object,
+  yScale?: Object,
+  color: Function,
+  xValue: Function,
+  xComparator: Function,
+  yValue: Function
+};
+
+export default class Line extends Component {
+  props: LineProps;
+  line: Object;
+  componentWillMount() {
+    this.line = getLine();
+  }
+  render() {
+    if (!this.props.chartingGroup) return;
+
+    const { chartingGroup } = this.props;
+
+    this.line
+      .interpolate(this.props.interpolate || 'linear')
+      .color(this.props.color)
+      .xScale(this.props.xScale)
+      .yScale(this.props.yScale)
+      .xValue(this.props.xValue)
+      .xComparator(this.props.xComparator)
+      .yValue(this.props.yValue);
+
+    chartingGroup.transition().duration(0).call(this.line);
+  }
+}

--- a/source/iml/charting/types/line/get-line.js
+++ b/source/iml/charting/types/line/get-line.js
@@ -5,159 +5,164 @@
 
 import * as fp from '@iml/fp';
 import d3 from 'd3';
+import global from '../../../global.js';
 
-export function getLineFactory($location) {
-  'ngInject';
-  let counter = 0;
+let counter = 0;
 
-  return function getLine() {
-    let xScale = fp.noop;
-    let yScale = fp.noop;
-    let xValue = fp.noop;
-    let yValue = fp.noop;
-    let xComparator = fp.noop;
-    let color = '#000000';
-    let opacity = 1;
+export default function getLine() {
+  let xScale = fp.noop;
+  let yScale = fp.noop;
+  let xValue = fp.noop;
+  let yValue = fp.noop;
+  let xComparator = fp.noop;
+  let color = '#000000';
+  let opacity = 1;
+  let interpolate = 'linear';
 
-    const count = (counter += 1);
+  const count = (counter += 1);
 
-    const strPlusCount = str => str + count;
+  const strPlusCount = str => str + count;
 
-    function line(selection) {
-      selection.each(function setData(data) {
-        const item = d3.select(this);
+  function line(selection) {
+    selection.each(function setData(data) {
+      const item = d3.select(this);
 
-        const clipCount = strPlusCount('clip');
+      const clipCount = strPlusCount('clip');
 
-        const clip = item.selectAll(`.${clipCount}`).data(['foo']);
+      const clip = item.selectAll(`.${clipCount}`).data(['foo']);
 
-        clip
-          .enter()
-          .append('defs')
-          .attr('class', clipCount)
-          .append('svg:clipPath')
-          .attr('id', clipCount)
-          .append('svg:rect');
+      clip
+        .enter()
+        .append('defs')
+        .attr('class', clipCount)
+        .append('svg:clipPath')
+        .attr('id', clipCount)
+        .append('svg:rect');
 
-        clip
-          .selectAll('rect')
-          .attr('width', xScale.range()[1])
-          .attr('height', yScale.range()[0]);
+      clip
+        .selectAll('rect')
+        .attr('width', xScale.range()[xScale.range().length - 1])
+        .attr('height', yScale.range()[0]);
 
-        const clipGroup = item
-          .selectAll(`.${strPlusCount('clipPath')}`)
-          .data(['foo']);
+      const clipGroup = item
+        .selectAll(`.${strPlusCount('clipPath')}`)
+        .data(['foo']);
 
-        clipGroup
-          .enter()
-          .append('g')
-          .attr(
-            'clip-path',
-            `url(${$location.absUrl()}${strPlusCount('#clip')})`
-          )
-          .attr('class', strPlusCount('clipPath'));
+      clipGroup
+        .enter()
+        .append('g')
+        .attr(
+          'clip-path',
+          `url(${global.location.href}${strPlusCount('#clip')})`
+        )
+        .attr('class', strPlusCount('clipPath'));
 
-        const line = d3.svg
-          .line()
-          .x(fp.flow(xValue, xScale))
-          .y(fp.flow(yValue, yScale));
+      const line = d3.svg
+        .line()
+        .interpolate(interpolate)
+        .x(fp.flow(xValue, xScale))
+        .y(fp.flow(yValue, yScale));
 
-        const lineCount = strPlusCount('line');
-        const lineClassCount = `.${lineCount}`;
+      const lineCount = strPlusCount('line');
+      const lineClassCount = `.${lineCount}`;
 
-        let lineEl = clipGroup.selectAll(lineClassCount);
+      let lineEl = clipGroup.selectAll(lineClassCount);
 
-        const shouldShift =
-          lineEl.size() &&
-          data.length &&
-          !xComparator(xValue(data[0]), xValue(lineEl.datum()[0]));
+      const shouldShift =
+        lineEl.size() &&
+        data.length &&
+        !xComparator(xValue(data[0]), xValue(lineEl.datum()[0]));
 
-        if (shouldShift) data = [lineEl.datum()[0]].concat(data);
+      if (shouldShift) data = [lineEl.datum()[0]].concat(data);
 
-        const wrappedData = data.length ? [data] : data;
-        lineEl = lineEl.data(wrappedData);
+      const wrappedData = data.length ? [data] : data;
+      lineEl = lineEl.data(wrappedData);
 
-        lineEl
-          .transition('moving')
-          .attr('d', line)
-          .attr('stroke', color)
-          .style('stroke-opacity', opacity)
-          .each('end', function removeOldPoint() {
-            if (shouldShift)
-              d3.select(this).datum(data.slice(1)).attr('d', line);
-          });
+      lineEl
+        .transition('moving')
+        .attr('d', line)
+        .attr('stroke', color)
+        .style('stroke-opacity', opacity)
+        .each('end', function removeOldPoint() {
+          if (shouldShift) d3.select(this).datum(data.slice(1)).attr('d', line);
+        });
 
-        lineEl
-          .enter()
-          .append('svg:path')
-          .classed(`line ${lineCount}`, true)
-          .attr('stroke', color)
-          .attr('d', line)
-          .style('stroke-opacity', opacity)
-          .each(function animateEntering() {
-            const totalLength = this.getTotalLength();
+      lineEl
+        .enter()
+        .append('svg:path')
+        .classed(`line ${lineCount}`, true)
+        .attr('stroke', color)
+        .attr('d', line)
+        .style('stroke-opacity', opacity)
+        .each(function animateEntering() {
+          const totalLength = this.getTotalLength();
 
-            d3
-              .select(this)
-              .attr('stroke-dasharray', `${totalLength} ${totalLength}`)
-              .attr('stroke-dashoffset', totalLength);
-          })
-          .transition('entering')
-          .attr('stroke-dashoffset', 0)
-          .each('end', function resetDashArray() {
-            d3.select(this).attr('stroke-dasharray', null);
-          });
+          d3
+            .select(this)
+            .attr('stroke-dasharray', `${totalLength} ${totalLength}`)
+            .attr('stroke-dashoffset', totalLength);
+        })
+        .transition('entering')
+        .attr('stroke-dashoffset', 0)
+        .each('end', function resetDashArray() {
+          d3.select(this).attr('stroke-dasharray', null);
+        });
 
-        lineEl.exit().remove();
-      });
-    }
+      lineEl.exit().remove();
+    });
+  }
 
-    line.color = function colorAccessor(_) {
-      if (!arguments.length) return color;
-      color = _;
-      return line;
-    };
-
-    line.xValue = function xValueAccessor(_) {
-      if (!arguments.length) return xValue;
-      xValue = _;
-      return line;
-    };
-
-    line.yValue = function yValueAccessor(_) {
-      if (!arguments.length) return yValue;
-      yValue = _;
-      return line;
-    };
-
-    line.xScale = function xScaleAccessor(_) {
-      if (!arguments.length) return xScale;
-      xScale = _;
-      return line;
-    };
-
-    line.yScale = function yScaleAccessor(_) {
-      if (!arguments.length) return yScale;
-      yScale = _;
-      return line;
-    };
-
-    line.xComparator = function xComparatorAccessor(_) {
-      if (!arguments.length) return xComparator;
-      xComparator = _;
-      return line;
-    };
-
-    line.opacity = function opacityAccessor(_) {
-      if (!arguments.length) return opacity;
-      opacity = _;
-      return line;
-    };
-
-    line.getCount = function getCount() {
-      return count;
-    };
-
+  line.color = function colorAccessor(_) {
+    if (!arguments.length) return color;
+    color = _;
     return line;
   };
+
+  line.xValue = function xValueAccessor(_) {
+    if (!arguments.length) return xValue;
+    xValue = _;
+    return line;
+  };
+
+  line.yValue = function yValueAccessor(_) {
+    if (!arguments.length) return yValue;
+    yValue = _;
+    return line;
+  };
+
+  line.xScale = function xScaleAccessor(_) {
+    if (!arguments.length) return xScale;
+    xScale = _;
+    return line;
+  };
+
+  line.yScale = function yScaleAccessor(_) {
+    if (!arguments.length) return yScale;
+    yScale = _;
+    return line;
+  };
+
+  line.xComparator = function xComparatorAccessor(_) {
+    if (!arguments.length) return xComparator;
+    xComparator = _;
+    return line;
+  };
+
+  line.opacity = function opacityAccessor(_) {
+    if (!arguments.length) return opacity;
+    opacity = _;
+    return line;
+  };
+
+  line.getCount = function getCount() {
+    return count;
+  };
+
+  line.interpolate = _ => {
+    if (_ == null) return interpolate;
+    interpolate = _;
+    return line;
+  };
+
+  return line;
 }

--- a/source/iml/charting/types/line/line-directive.js
+++ b/source/iml/charting/types/line/line-directive.js
@@ -4,8 +4,9 @@
 // license that can be found in the LICENSE file.
 
 import * as fp from '@iml/fp';
+import getLine from './get-line.js';
 
-export function lineDirective(getLine) {
+export function lineDirective() {
   'ngInject';
   return {
     restrict: 'A',

--- a/source/iml/charting/types/line/line-module.js
+++ b/source/iml/charting/types/line/line-module.js
@@ -7,10 +7,6 @@
 
 import angular from 'angular';
 
-import { getLineFactory } from './get-line';
 import { lineDirective } from './line-directive';
 
-export default angular
-  .module('line', [])
-  .directive('line', lineDirective)
-  .factory('getLine', getLineFactory).name;
+export default angular.module('line', []).directive('line', lineDirective).name;

--- a/test/dom/iml/charting/__snapshots__/area-test.js.snap
+++ b/test/dom/iml/charting/__snapshots__/area-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render as expected 1`] = `
+<svg>
+  <g>
+    <g>
+      <path
+        class="area area1"
+        stroke="green"
+        fill="green"
+        fill-opacity="0.2"
+        d="M0,200L200,0L200,200L0,200Z"
+      />
+    </g>
+  </g>
+</svg>
+`;

--- a/test/dom/iml/charting/__snapshots__/axis-test.js.snap
+++ b/test/dom/iml/charting/__snapshots__/axis-test.js.snap
@@ -1,0 +1,428 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`axis should render x as expected 1`] = `
+<svg>
+  <g>
+    <g
+      class="axis x-axis"
+      transform="translate(0,180)"
+    >
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          0
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(20,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          10
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(40,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          20
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(60,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          30
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(80,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          40
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(100,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          50
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(120,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          60
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(140,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          70
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(160,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          80
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(180,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          90
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(200,0)"
+      >
+        <line
+          y2="6"
+          x2="0"
+        />
+        <text
+          dy=".71em"
+          style="text-anchor: middle;"
+          y="9"
+          x="0"
+        >
+          100
+        </text>
+      </g>
+      <path
+        class="domain"
+        d="M0,6V0H200V6"
+      />
+    </g>
+  </g>
+</svg>
+`;
+
+exports[`axis should render y as expected 1`] = `
+<svg>
+  <g>
+    <g
+      class="axis y-axis"
+    >
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,0)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          0
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,20)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          10
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,40)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          20
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,60)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          30
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,80)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          40
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,100)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          50
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,120)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          60
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,140)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          70
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,160)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          80
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,180)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          90
+        </text>
+      </g>
+      <g
+        class="tick"
+        style="opacity: 1;"
+        transform="translate(0,200)"
+      >
+        <line
+          x2="-6"
+          y2="0"
+        />
+        <text
+          dy=".32em"
+          style="text-anchor: end;"
+          x="-9"
+          y="0"
+        >
+          100
+        </text>
+      </g>
+      <path
+        class="domain"
+        d="M-6,0H0V200H-6"
+      />
+    </g>
+  </g>
+</svg>
+`;

--- a/test/dom/iml/charting/__snapshots__/chart-test.js.snap
+++ b/test/dom/iml/charting/__snapshots__/chart-test.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`charting should match 1`] = `
+<div>
+  <svg
+    style="width: 100%; height: 100%;"
+    class="charting"
+  >
+    <g
+      transform="translate(50,50)"
+      class="charting-group"
+    >
+      <div>
+        {"top":50,"right":50,"bottom":50,"left":50}
+      </div>
+      <div>
+        {"usableWidth":-100,"usableHeight":-100}
+      </div>
+      <div>
+        [1,2,3]
+      </div>
+    </g>
+  </svg>
+</div>
+`;
+
+exports[`charting should set state on resize 1`] = `
+<div
+  style="width: 500px; height: 500px;"
+>
+  <svg
+    style="width: 100%; height: 100%;"
+    class="charting"
+  >
+    <g
+      transform="translate(50,50)"
+      class="charting-group"
+    >
+      <div>
+        {"top":50,"right":50,"bottom":50,"left":50}
+      </div>
+      <div>
+        {"usableWidth":400,"usableHeight":400}
+      </div>
+      <div>
+        [1,2,3]
+      </div>
+    </g>
+  </svg>
+</div>
+`;

--- a/test/dom/iml/charting/__snapshots__/legend-test.js.snap
+++ b/test/dom/iml/charting/__snapshots__/legend-test.js.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render as expected 1`] = `
+<svg>
+  <g
+    class="legend chart-legend"
+  >
+    <g
+      class="legend-group"
+      transform="translate(0,0)"
+    >
+      <circle
+        class="legend-circle"
+        fill="green"
+        stroke="green"
+        fill-opacity="0"
+        r="5"
+      />
+      <text
+        class="legend-label"
+        dx="10"
+        dy="4"
+      >
+        foo
+      </text>
+    </g>
+    <g
+      class="legend-group"
+      transform="translate(20,0)"
+    >
+      <circle
+        class="legend-circle"
+        fill="blue"
+        stroke="blue"
+        fill-opacity="0"
+        r="5"
+      />
+      <text
+        class="legend-label"
+        dx="10"
+        dy="4"
+      >
+        bar
+      </text>
+    </g>
+  </g>
+</svg>
+`;
+
+exports[`should transform 1`] = `
+<svg>
+  <g
+    class="legend chart-legend"
+    transform="translate(0,100)"
+  >
+    <g
+      class="legend-group"
+      transform="translate(0,0)"
+    >
+      <circle
+        class="legend-circle"
+        fill="green"
+        stroke="green"
+        fill-opacity="0"
+        r="5"
+      />
+      <text
+        class="legend-label"
+        dx="10"
+        dy="4"
+      >
+        foo
+      </text>
+    </g>
+    <g
+      class="legend-group"
+      transform="translate(20,0)"
+    >
+      <circle
+        class="legend-circle"
+        fill="blue"
+        stroke="blue"
+        fill-opacity="0"
+        r="5"
+      />
+      <text
+        class="legend-label"
+        dx="10"
+        dy="4"
+      >
+        bar
+      </text>
+    </g>
+  </g>
+</svg>
+`;

--- a/test/dom/iml/charting/__snapshots__/line-test.js.snap
+++ b/test/dom/iml/charting/__snapshots__/line-test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`line tests should render as expected 1`] = `
+<svg>
+  <g>
+    <defs
+      class="clip1"
+    >
+      <clippath
+        id="clip1"
+      >
+        <rect
+          width="200"
+          height="200"
+        />
+      </clippath>
+    </defs>
+    <g
+      clip-path="url(about:blank#clip1)"
+      class="clipPath1"
+    >
+      <path
+        class="line line1"
+        stroke="green"
+        d="M0,200L200,0"
+        style="stroke-opacity: 1;"
+        stroke-dasharray="100 100"
+        stroke-dashoffset="100"
+      />
+    </g>
+  </g>
+</svg>
+`;

--- a/test/dom/iml/charting/area-test.js
+++ b/test/dom/iml/charting/area-test.js
@@ -1,0 +1,29 @@
+// @flow
+
+import Inferno from 'inferno';
+
+import Area from '../../../../source/iml/charting/area.js';
+import d3 from 'd3';
+
+it('should render as expected', () => {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const chartingGroup = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'g'
+  );
+  svg.appendChild(chartingGroup);
+
+  Inferno.render(
+    <Area
+      xScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+      yScale={d3.scale.linear().domain([0, 100]).range([200, 0])}
+      xValue={x => x}
+      y1Value={x => x}
+      chartingGroup={d3.select(chartingGroup).datum([0, 100])}
+      color={'green'}
+    />,
+    svg
+  );
+
+  expect(svg).toMatchSnapshot();
+});

--- a/test/dom/iml/charting/axis-test.js
+++ b/test/dom/iml/charting/axis-test.js
@@ -1,0 +1,95 @@
+// @flow
+
+import Inferno from 'inferno';
+
+import Axis from '../../../../source/iml/charting/axis.js';
+import d3 from 'd3';
+
+describe('axis', () => {
+  let svg, chartingGroup;
+
+  beforeEach(() => {
+    svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    chartingGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    svg.appendChild(chartingGroup);
+  });
+
+  it('should render x as expected', () => {
+    Inferno.render(
+      <Axis
+        type="x"
+        xScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+        dimensions={{ usableWidth: 200, usableHeight: 200 }}
+        chartingGroup={d3.select(chartingGroup).datum([0, 100])}
+      />,
+      svg
+    );
+
+    expect(svg).toMatchSnapshot();
+  });
+
+  it('should render y as expected', () => {
+    Inferno.render(
+      <Axis
+        type="y"
+        yScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+        dimensions={{ usableWidth: 200, usableHeight: 200 }}
+        chartingGroup={d3.select(chartingGroup).datum([0, 100])}
+      />,
+      svg
+    );
+
+    expect(svg).toMatchSnapshot();
+
+    Inferno.render(null, svg);
+  });
+
+  it('should throw when props are missing', () => {
+    expect.assertions(2);
+
+    expect(() =>
+      Inferno.render(
+        <Axis
+          type="y"
+          yScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+          chartingGroup={d3.select(chartingGroup).datum([0, 100])}
+        />,
+        svg
+      )
+    ).toThrow();
+
+    expect(() =>
+      Inferno.render(
+        <Axis
+          type="y"
+          yScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+          dimensions={{ usableWidth: 200, usableHeight: 200 }}
+        />,
+        svg
+      )
+    ).toThrow();
+  });
+
+  it('should skip cleanup', () => {
+    Inferno.render(
+      <Axis
+        type="y"
+        yScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+        dimensions={{ usableWidth: 200, usableHeight: 200 }}
+        chartingGroup={d3.select(chartingGroup).datum([0, 100])}
+      />,
+      svg
+    );
+
+    Inferno.render(
+      <Axis
+        type="y"
+        yScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+        dimensions={{ usableWidth: 200, usableHeight: 200 }}
+      />,
+      svg
+    );
+
+    Inferno.render(null, svg);
+  });
+});

--- a/test/dom/iml/charting/chart-test.js
+++ b/test/dom/iml/charting/chart-test.js
@@ -1,0 +1,85 @@
+// @flow
+
+import Inferno from 'inferno';
+
+import { renderToSnapshot } from '../../../test-utils.js';
+
+const Child = (props: Object) =>
+  <div>
+    {JSON.stringify(props[props.propName])}
+  </div>;
+
+describe('charting', () => {
+  let Chart;
+
+  beforeEach(() => {
+    jest.mock('@iml/debounce', () => fn => fn);
+
+    Chart = require('../../../../source/iml/charting/chart.js').default;
+  });
+
+  it('should match', () => {
+    expect(
+      renderToSnapshot(
+        <Chart
+          margins={{ top: 50, right: 50, bottom: 50, left: 50 }}
+          points={[1, 2, 3]}
+        >
+          <Child propName="margins" />
+          <Child propName="dimensions" />
+          <Child propName="points" />
+        </Chart>
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('should set state on resize', () => {
+    const root = document.createElement('div');
+    root.style.setProperty('width', '500px');
+    root.style.setProperty('height', '500px');
+
+    Inferno.render(
+      <Chart
+        margins={{ top: 50, right: 50, bottom: 50, left: 50 }}
+        points={[1, 2, 3]}
+      >
+        <Child propName="margins" />
+        <Child propName="dimensions" />
+        <Child propName="points" />
+      </Chart>,
+      root
+    );
+
+    // $FlowFixMe: Mocking for test
+    root.querySelector('svg').getBoundingClientRect = () => ({
+      width: 500,
+      height: 500
+    });
+
+    window.dispatchEvent(new Event('resize', { bubbles: true }));
+
+    expect(root).toMatchSnapshot();
+  });
+
+  it('should cleanup when unmounting', () => {
+    jest.spyOn(window, 'removeEventListener');
+
+    const root = document.createElement('div');
+    root.style.setProperty('width', '500px');
+    root.style.setProperty('height', '500px');
+
+    Inferno.render(
+      <Chart
+        margins={{ top: 50, right: 50, bottom: 50, left: 50 }}
+        points={[1, 2, 3]}
+      >
+        <Child propName="margins" />
+        <Child propName="dimensions" />
+        <Child propName="points" />
+      </Chart>,
+      root
+    );
+
+    Inferno.render(null, root);
+  });
+});

--- a/test/dom/iml/charting/legend-test.js
+++ b/test/dom/iml/charting/legend-test.js
@@ -1,0 +1,43 @@
+// @flow
+
+import Inferno from 'inferno';
+
+import Legend from '../../../../source/iml/charting/legend.js';
+import d3 from 'd3';
+
+it('should render as expected', () => {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+  Inferno.render(
+    <Legend
+      svg={d3.select(svg).datum([0, 100])}
+      dimensions={{ usableWidth: 200, usableHeight: 200 }}
+      colors={d3.scale
+        .ordinal()
+        .domain(['foo', 'bar'])
+        .range(['green', 'blue'])}
+    />,
+    svg
+  );
+
+  expect(svg).toMatchSnapshot();
+});
+
+it('should transform', () => {
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+  Inferno.render(
+    <Legend
+      svg={d3.select(svg).datum([0, 100])}
+      dimensions={{ usableWidth: 200, usableHeight: 200 }}
+      transform="translate(0,100)"
+      colors={d3.scale
+        .ordinal()
+        .domain(['foo', 'bar'])
+        .range(['green', 'blue'])}
+    />,
+    svg
+  );
+
+  expect(svg).toMatchSnapshot();
+});

--- a/test/dom/iml/charting/line-test.js
+++ b/test/dom/iml/charting/line-test.js
@@ -1,0 +1,41 @@
+// @flow
+
+import Inferno from 'inferno';
+
+import Line from '../../../../source/iml/charting/line.js';
+import d3 from 'd3';
+
+describe('line tests', () => {
+  let svg, chartingGroup;
+
+  beforeEach(() => {
+    // $FlowFixMe: Mock for test
+    Element.prototype.getTotalLength = () => 100;
+
+    svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    chartingGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    svg.appendChild(chartingGroup);
+  });
+
+  afterEach(() => {
+    // $FlowFixMe: Mock for test
+    delete Element.prototype.getTotalLength;
+  });
+
+  it('should render as expected', () => {
+    Inferno.render(
+      <Line
+        xScale={d3.scale.linear().domain([0, 100]).range([0, 200])}
+        yScale={d3.scale.linear().domain([0, 100]).range([200, 0])}
+        xValue={x => x}
+        yValue={x => x}
+        xComparator={(x, y) => x === y}
+        chartingGroup={d3.select(chartingGroup).datum([0, 100])}
+        color={() => 'green'}
+      />,
+      svg
+    );
+
+    expect(svg).toMatchSnapshot();
+  });
+});

--- a/test/dom/iml/charting/types/line/get-line-test.js
+++ b/test/dom/iml/charting/types/line/get-line-test.js
@@ -1,8 +1,7 @@
 import * as fp from '@iml/fp';
-import d3 from 'd3';
+import { default as mockD3 } from 'd3';
 import { gt } from '@iml/math';
 import { flushD3Transitions } from '../../../../../test-utils.js';
-import { getLineFactory } from '../../../../../../source/iml/charting/types/line/get-line';
 
 const viewLens = fp.flow(fp.lensProp, fp.view);
 const getCoord = (curr, idx) => Math.round(curr.split(',')[idx]);
@@ -24,12 +23,22 @@ describe('get line', () => {
         return arr;
       }, []);
   }
+
   let getLine, div, svg, query;
 
   beforeEach(() => {
+    jest.mock('d3', () => mockD3);
+
+    jest.mock('../../../../../../source/iml/global.js', () => ({
+      location: {
+        href: 'https://foo/'
+      }
+    }));
+
+    getLine = require('../../../../../../source/iml/charting/types/line/get-line')
+      .default;
+
     Element.prototype.getTotalLength = () => 100;
-    const $location = { absUrl: fp.always('https://foo/') };
-    getLine = getLineFactory($location, d3);
     div = document.createElement('div');
     svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.setAttribute('width', 500);
@@ -51,14 +60,17 @@ describe('get line', () => {
     beforeEach(() => {
       inst = getLine();
       spy = jest.fn();
-      const x = d3.scale.linear();
+
+      const x = mockD3.scale.linear();
       x.range([0, 100]);
-      const y = d3.scale.linear();
+
+      const y = mockD3.scale.linear();
       y.range([100, 0]);
-      svg = d3.select(svg).append('g');
+
+      svg = mockD3.select(svg).append('g');
       setup = d => {
-        x.domain([0, d3.max(d, viewLens('x'))]);
-        y.domain([0, d3.max(d, viewLens('y'))]);
+        x.domain([0, mockD3.max(d, viewLens('x'))]);
+        y.domain([0, mockD3.max(d, viewLens('y'))]);
         inst
           .xScale(x)
           .yScale(y)
@@ -72,70 +84,90 @@ describe('get line', () => {
     it('should have a color accessor', () => {
       expect(inst.color()).toEqual('#000000');
     });
+
     it('should have a color setter', () => {
       inst.color('#111111');
       expect(inst.color()).toEqual('#111111');
     });
+
     it('should have an xValue accessor', () => {
-      expect(inst.xValue()).toBe(fp.noop);
+      expect(inst.xValue()).toEqual(expect.any(Function));
     });
+
     it('should have an xValue setter', () => {
       inst.xValue(spy);
       expect(inst.xValue()).toBe(spy);
     });
+
     it('should have a yValue accessor', () => {
-      expect(inst.yValue()).toBe(fp.noop);
+      expect(inst.yValue()).toEqual(expect.any(Function));
     });
+
     it('should have a yValue setter', () => {
       inst.yValue(spy);
       expect(inst.yValue()).toBe(spy);
     });
+
     it('should have an xScale accessor', () => {
-      expect(inst.xScale()).toBe(fp.noop);
+      expect(inst.xScale()).toEqual(expect.any(Function));
     });
+
     it('should have a xScale setter', () => {
       inst.xScale(spy);
       expect(inst.xScale()).toBe(spy);
     });
+
     it('should have a yScale accessor', () => {
-      expect(inst.yScale()).toBe(fp.noop);
+      expect(inst.yScale()).toEqual(expect.any(Function));
     });
+
     it('should have a yScale setter', () => {
       inst.yScale(spy);
       expect(inst.yScale()).toBe(spy);
     });
+
     it('should have an xComparator accessor', () => {
-      expect(inst.xComparator()).toBe(fp.noop);
+      expect(inst.xComparator()).toEqual(expect.any(Function));
     });
+
     it('should have an xComparator setter', () => {
       inst.xComparator(spy);
       expect(inst.xComparator()).toBe(spy);
     });
+
     it('should have an opacity accessor', () => {
       expect(inst.opacity()).toBe(1);
     });
+
     it('should have an opacity setter', () => {
       inst.opacity(0);
       expect(inst.opacity()).toBe(0);
     });
+
     it('should have a count getter', () => {
-      expect(inst.getCount()).toBe(1);
+      expect(inst.getCount()).toEqual(1);
     });
+
     describe('with data', () => {
       let line;
+
       beforeEach(() => {
         setup([{ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }]);
         line = query('.clipPath1 path.line1');
       });
+
       it('should add a clip path', () => {
         expect(query('clipPath#clip1')).toBeDefined();
       });
+
       it('should set the clipping to rectangle the scale width', () => {
         expect(query('rect').getAttribute('width')).toEqual('100');
       });
+
       it('should set the clipping rectangle to the scale height', () => {
         expect(query('rect').getAttribute('height')).toEqual('100');
       });
+
       it('should set the corresponding clip path', () => {
         expect(query('.clipPath1').getAttribute('clip-path')).toEqual(
           'url(https://foo/#clip1)'
@@ -144,9 +176,11 @@ describe('get line', () => {
       it('should calculate the line from data', () => {
         expect(line.getAttribute('d')).toEqual('M0,100L50,50L100,0');
       });
+
       it('should set the color on the line', () => {
         expect(line.getAttribute('stroke')).toEqual('#000000');
       });
+
       it('should set stroke-dasharray to the total length of the line', () => {
         expect.assertions(2);
         line
@@ -155,43 +189,51 @@ describe('get line', () => {
           .map(fp.unary(parseInt))
           .forEach(x => expect(x).toBeGreaterThan(0));
       });
+
       it('should set stroke-dashoffset to the total length of the line', () => {
         expect(
           parseInt(line.getAttribute('stroke-dashoffset'))
         ).toBeGreaterThan(0);
       });
+
       it('should animate stroke-dashoffset to 0', () => {
-        flushD3Transitions(d3);
+        flushD3Transitions(mockD3);
         expect(line.getAttribute('stroke-dashoffset')).toEqual('0');
       });
+
       it('should animate stroke-dasharray to 0', () => {
-        flushD3Transitions(d3);
+        flushD3Transitions(mockD3);
         expect(line.getAttribute('stroke-dasharray')).toBeNull();
       });
+
       describe('and updating', () => {
         beforeEach(() => {
-          flushD3Transitions(d3);
+          flushD3Transitions(mockD3);
           setup([{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 3 }]);
         });
 
         describe('previous layout', () => {
           let coords;
+
           beforeEach(() => {
             coords = getCoords(line);
           });
+
           it('should move to 0,100', () => {
             expect(coords[0]).toEqual({ type: 'M', x: 0, y: 100 });
           });
+
           it('should draw a line to 50,50', () => {
             expect(coords[1]).toEqual({ type: 'L', x: 50, y: 50 });
           });
+
           it('should draw a line to 100,0', () => {
             expect(coords[2]).toEqual({ type: 'L', x: 100, y: 0 });
           });
         });
 
         it('should update the line data keep the previous point and duplicate the last point', () => {
-          expect(d3.select(line).datum()).toEqual([
+          expect(mockD3.select(line).datum()).toEqual([
             { x: 0, y: 0 },
             { x: 1, y: 1 },
             { x: 2, y: 2 },
@@ -202,34 +244,40 @@ describe('get line', () => {
         describe('ending layout', () => {
           let coords;
           beforeEach(() => {
-            flushD3Transitions(d3);
+            flushD3Transitions(mockD3);
             coords = getCoords(line);
           });
+
           it('should move to 33,67', () => {
             expect(coords[0]).toEqual({ type: 'M', x: 33, y: 67 });
           });
+
           it('should draw a line to 67,33', () => {
             expect(coords[1]).toEqual({ type: 'L', x: 67, y: 33 });
           });
+
           it('should draw a line to 100,0', () => {
             expect(coords[2]).toEqual({ type: 'L', x: 100, y: 0 });
           });
         });
+
         it('should end with new data', () => {
-          flushD3Transitions(d3);
-          expect(d3.select(line).datum()).toEqual([
+          flushD3Transitions(mockD3);
+          expect(mockD3.select(line).datum()).toEqual([
             { x: 1, y: 1 },
             { x: 2, y: 2 },
             { x: 3, y: 3 }
           ]);
         });
       });
+
       describe('and exiting', () => {
         beforeEach(() => {
-          flushD3Transitions(d3);
+          flushD3Transitions(mockD3);
           setup([]);
-          flushD3Transitions(d3);
+          flushD3Transitions(mockD3);
         });
+
         it('should remove the line', () => {
           expect(query('.clipPath1 path.line1')).toBeNull();
         });

--- a/test/dom/iml/charting/types/line/line-directive-test.js
+++ b/test/dom/iml/charting/types/line/line-directive-test.js
@@ -2,7 +2,6 @@ import d3 from 'd3';
 import highland from 'highland';
 import * as fp from '@iml/fp';
 import { lineDirective } from '../../../../../../source/iml/charting/types/line/line-directive.js';
-import { getLineFactory } from '../../../../../../source/iml/charting/types/line/get-line.js';
 import { charterDirective } from '../../../../../../source/iml/charting/types/chart/chart-directive.js';
 import { flushD3Transitions } from '../../../../../test-utils.js';
 import angular from '../../../../../angular-mock-setup.js';
@@ -11,10 +10,9 @@ describe('line directive', () => {
   let chartCtrl;
 
   beforeEach(
-    angular.mock.module(($compileProvider, $provide) => {
+    angular.mock.module($compileProvider => {
       Element.prototype.getTotalLength = () => 0;
       $compileProvider.directive('line', lineDirective);
-      $provide.factory('getLine', getLineFactory);
       $compileProvider.directive('charter', charterDirective);
       $compileProvider.directive('tester', () => {
         return {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -11,10 +11,13 @@ export const extendWithConstructor = (constructor, obj) => {
 
 export const flushD3Transitions = d3 => {
   const now = Date.now;
+
   Date.now = function() {
     return Infinity;
   };
+
   d3.timer.flush();
+
   Date.now = now;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@iml/debounce@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@iml/debounce/-/debounce-1.0.1.tgz#af4c76bec7a6c0d5aff363386e3703809856e4ae"
+"@iml/debounce@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@iml/debounce/-/debounce-1.0.2.tgz#5c098820b3c79e56e5a6a2a9cd659fe727f4275f"
 
 "@iml/deep-freeze@2.0.2":
   version "2.0.2"
@@ -1868,9 +1868,9 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.4.0.tgz#a3e153e704b64f78290ef03592494eaba228d3bc"
+eslint@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.4.1.tgz#99cd7eafcffca2ff99a5c8f5f2a474d6364b4bd3"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"


### PR DESCRIPTION
Implement some chart components for inferno.

This will allow us to declaratively create charts using html. Example (pseudocode following):

```
<Chart>
   <Axis />
   <Line />
</Chart>
```

There are a few rules that make this easier.

1. Only pass changes downward, no handlers for
chart updating on the chart component itself
2. We skip scales as a component. They are
the variant part of making a chart in many
cases, we can just create them inline during
usage.
3. Each component will pass it's props, and useful
parent props to their children. This ensures that
scales and such are propagated where they should be.