### PR TITLE
Integrate Online Help

### DIFF
--- a/source/iml/dashboard/dashboard-states.js
+++ b/source/iml/dashboard/dashboard-states.js
@@ -140,7 +140,7 @@ export const dashboardState = {
     targetsB: dashboardTargetB
   },
   data: {
-    helpPage: 'dashboard_charts.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.1',
     anonymousReadProtected: true,
     eulaState: true
   },

--- a/source/iml/file-system/file-system-states.js
+++ b/source/iml/file-system/file-system-states.js
@@ -27,7 +27,7 @@ export const fileSystemListState = {
     }
   },
   data: {
-    helpPage: 'file_systems_tab.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.3.3',
     access: GROUPS.FS_ADMINS,
     anonymousReadProtected: true,
     eulaState: true,

--- a/source/iml/help-mapper/help-mapper-directive.js
+++ b/source/iml/help-mapper/help-mapper-directive.js
@@ -10,7 +10,7 @@ import * as maybe from '@iml/maybe';
 export default () => ({
   restrict: 'A',
   template: `
-<a id="help-menu" ng-href="/static/webhelp/{{vm.page}}" target="_blank">
+<a id="help-menu" ng-href="/help/{{vm.page}}" target="_blank">
   <i class="fa fa-question-circle"></i> Help
 </a>
   `,

--- a/source/iml/help-mapper/help-mapper-directive.js
+++ b/source/iml/help-mapper/help-mapper-directive.js
@@ -23,7 +23,7 @@ export default () => ({
       maybe.withDefault(
         () => '',
         maybe.map(
-          (x: string) => `?${x}`,
+          (x: string) => `docs/${x}`,
           maybe.of($current.data && $current.data.helpPage)
         )
       );

--- a/source/iml/hsm/hsm-states.js
+++ b/source/iml/hsm/hsm-states.js
@@ -51,7 +51,7 @@ export const hsmFsState = {
   <ui-loader-view class="section-top-margin"></ui-loader-view>
 </div>`,
   data: {
-    helpPage: 'hsm_page.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.3.4',
     access: GROUPS.FS_ADMINS,
     anonymousReadProtected: true,
     eulaState: true

--- a/source/iml/job-stats/job-stats-states.js
+++ b/source/iml/job-stats/job-stats-states.js
@@ -20,7 +20,7 @@ export const jobStatsState = {
     }
   },
   data: {
-    helpPage: 'view_job_statistics.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.4',
     anonymousReadProtected: true,
     eulaState: true,
     kind: 'Job Stats',

--- a/source/iml/logs/log-states.js
+++ b/source/iml/logs/log-states.js
@@ -23,7 +23,7 @@ import type { qsFromLocationT } from '../qs-from-location/qs-from-location-modul
 export const logState = {
   name: 'app.log',
   data: {
-    helpPage: 'logs_page.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.5',
     anonymousReadProtected: true,
     eulaState: true
   },

--- a/source/iml/mgt/mgt-states.js
+++ b/source/iml/mgt/mgt-states.js
@@ -19,7 +19,7 @@ export const mgtState = {
     }
   },
   data: {
-    helpPage: 'mgts_tab.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.3.8',
     access: GROUPS.FS_ADMINS,
     anonymousReadProtected: true,
     eulaState: true,

--- a/source/iml/server/server-states.js
+++ b/source/iml/server/server-states.js
@@ -191,7 +191,7 @@ export const serverState = {
   </div>
 </div>`,
   data: {
-    helpPage: 'server_tab.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.3.1',
     access: GROUPS.FS_ADMINS,
     anonymousReadProtected: true,
     eulaState: true,
@@ -294,7 +294,7 @@ export const serverDetailState = {
     }
   },
   data: {
-    helpPage: 'server_detail_page.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.3.1.1',
     access: GROUPS.FS_ADMINS,
     anonymousReadProtected: true,
     eulaState: true,

--- a/source/iml/status/status-states.js
+++ b/source/iml/status/status-states.js
@@ -18,7 +18,7 @@ import type { qsFromLocationT } from '../qs-from-location/qs-from-location-modul
 export const statusState = {
   name: 'app.status',
   data: {
-    helpPage: 'status_page.htm',
+    helpPage: 'Graphical_User_Interface_9_0.html#9.6',
     anonymousReadProtected: true,
     eulaState: true
   },

--- a/test/dom/iml/help-mapper/help-mapper-directive-test.js
+++ b/test/dom/iml/help-mapper/help-mapper-directive-test.js
@@ -52,7 +52,7 @@ describe('help mapper', () => {
         globals: {
           $current: {
             data: {
-              helpPage: 'server_tab.htm'
+              helpPage: 'Graphical_User_Interface_9_0.html#9.3.1'
             }
           }
         }
@@ -62,7 +62,7 @@ describe('help mapper', () => {
     $scope.$digest();
 
     expect(el.querySelector('a').getAttribute('ng-href')).toBe(
-      '/static/webhelp/?server_tab.htm'
+      '/static/webhelp/docs/Graphical_User_Interface_9_0.html#9.3.1'
     );
   });
 });

--- a/test/dom/iml/help-mapper/help-mapper-directive-test.js
+++ b/test/dom/iml/help-mapper/help-mapper-directive-test.js
@@ -38,13 +38,11 @@ describe('help mapper', () => {
     expect(el.querySelector('a')).not.toBeNull();
   });
 
-  it('should not end with a qs', () => {
-    expect(el.querySelector('a').getAttribute('ng-href')).toBe(
-      '/static/webhelp/'
-    );
+  it('should not end with /help/', () => {
+    expect(el.querySelector('a').getAttribute('ng-href')).toBe('/help/');
   });
 
-  it('should end with a qs on matching route change', () => {
+  it('should end with a path plus hash on matching route change', () => {
     const fn = $transitions.onSuccess.mock.calls[0][1];
 
     fn({
@@ -62,7 +60,7 @@ describe('help mapper', () => {
     $scope.$digest();
 
     expect(el.querySelector('a').getAttribute('ng-href')).toBe(
-      '/static/webhelp/docs/Graphical_User_Interface_9_0.html#9.3.1'
+      '/help/docs/Graphical_User_Interface_9_0.html#9.3.1'
     );
   });
 });

--- a/test/spec/iml/dashboard/dashboard-states-test.js
+++ b/test/spec/iml/dashboard/dashboard-states-test.js
@@ -70,7 +70,7 @@ describe('dashboard states', () => {
         data: {
           anonymousReadProtected: true,
           eulaState: true,
-          helpPage: 'dashboard_charts.htm'
+          helpPage: 'Graphical_User_Interface_9_0.html#9.1'
         },
         controller: 'DashboardCtrl',
         controllerAs: 'dashboard',

--- a/test/spec/iml/file-system/file-system-states-test.js
+++ b/test/spec/iml/file-system/file-system-states-test.js
@@ -30,7 +30,7 @@ describe('file system states', () => {
         }
       },
       data: {
-        helpPage: 'file_systems_tab.htm',
+        helpPage: 'Graphical_User_Interface_9_0.html#9.3.3',
         access: mockGroups.FS_ADMINS,
         anonymousReadProtected: true,
         eulaState: true,

--- a/test/spec/iml/hsm/hsm-states-test.js
+++ b/test/spec/iml/hsm/hsm-states-test.js
@@ -76,7 +76,7 @@ describe('hsm states', () => {
           fsStream: 'fsCollStream'
         },
         data: {
-          helpPage: 'hsm_page.htm',
+          helpPage: 'Graphical_User_Interface_9_0.html#9.3.4',
           access: mockGroups.FS_ADMINS,
           anonymousReadProtected: true,
           eulaState: true

--- a/test/spec/iml/job-stats/job-stats-states-test.js
+++ b/test/spec/iml/job-stats/job-stats-states-test.js
@@ -35,7 +35,7 @@ describe('job stats states', () => {
         }
       },
       data: {
-        helpPage: 'view_job_statistics.htm',
+        helpPage: 'Graphical_User_Interface_9_0.html#9.4',
         anonymousReadProtected: true,
         eulaState: true,
         kind: 'Job Stats',

--- a/test/spec/iml/logs/log-states-test.js
+++ b/test/spec/iml/logs/log-states-test.js
@@ -39,7 +39,7 @@ describe('status states', () => {
       expect(mod.logState).toEqual({
         name: 'app.log',
         data: {
-          helpPage: 'logs_page.htm',
+          helpPage: 'Graphical_User_Interface_9_0.html#9.5',
           anonymousReadProtected: true,
           eulaState: true
         },

--- a/test/spec/iml/mgt/mgt-states-test.js
+++ b/test/spec/iml/mgt/mgt-states-test.js
@@ -39,7 +39,7 @@ describe('mgt states', () => {
         }
       },
       data: {
-        helpPage: 'mgts_tab.htm',
+        helpPage: 'Graphical_User_Interface_9_0.html#9.3.8',
         access: mockGroups.FS_ADMINS,
         anonymousReadProtected: true,
         eulaState: true,

--- a/test/spec/iml/server/server-states-test.js
+++ b/test/spec/iml/server/server-states-test.js
@@ -221,7 +221,7 @@ describe('server states', () => {
           }
         },
         data: {
-          helpPage: 'server_tab.htm',
+          helpPage: 'Graphical_User_Interface_9_0.html#9.3.1',
           access: mockGroups.FS_ADMINS,
           anonymousReadProtected: true,
           eulaState: true,
@@ -323,7 +323,7 @@ describe('server states', () => {
           }
         },
         data: {
-          helpPage: 'server_detail_page.htm',
+          helpPage: 'Graphical_User_Interface_9_0.html#9.3.1.1',
           access: mockGroups.FS_ADMINS,
           anonymousReadProtected: true,
           eulaState: true,

--- a/test/spec/iml/status/status-states-test.js
+++ b/test/spec/iml/status/status-states-test.js
@@ -23,7 +23,7 @@ describe('status states', () => {
       expect(mod.statusState).toEqual({
         name: 'app.status',
         data: {
-          helpPage: 'status_page.htm',
+          helpPage: 'Graphical_User_Interface_9_0.html#9.6',
           anonymousReadProtected: true,
           eulaState: true
         },


### PR DESCRIPTION
Now that online help has been packaged into manager for lustre
dependencies we can update the help mapper to point to the new locations
in online help.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>