### PR TITLE
Fix chart issues

### DIFF
--- a/source/iml/api-transforms.js
+++ b/source/iml/api-transforms.js
@@ -19,7 +19,7 @@ export function addCurrentPage<T: { meta: Object }>(o: T): T {
   };
 }
 
-export const matchById = (id: string) => fp.find(x => x.id === id);
+export const matchById = (id: string) => fp.find(x => x.id === parseInt(id));
 
 type MapFn<A, B> = A => B;
 export const rememberValue = <A, B, C: HighlandStreamT<B> | B[]>(

--- a/source/iml/dashboard/base-dashboard-chart-resolves.js
+++ b/source/iml/dashboard/base-dashboard-chart-resolves.js
@@ -5,13 +5,9 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-import angular from 'angular';
-import broadcaster from '../broadcaster.js';
-import * as fp from '@iml/fp';
-
-import type { HighlandStreamT } from 'highland';
-
 import type { chartT, chartTitleT, chartTitleKeyT } from './dashboard-types.js';
+
+import angular from 'angular';
 
 export function baseDashboardChartResolves(
   $stateParams: { id?: string },
@@ -66,12 +62,4 @@ export function baseDashboardChartResolves(
       id ? `oss${id}` : 'ossbase'
     )
   ]);
-}
-
-export function baseDashboardFsStream(
-  fsB: () => HighlandStreamT<Object[]>,
-  $stateParams: { id: string }
-) {
-  'ngInject';
-  return broadcaster(fsB().map(fp.filter(x => x.id === $stateParams.id)));
 }

--- a/source/iml/dashboard/dashboard-states.js
+++ b/source/iml/dashboard/dashboard-states.js
@@ -16,10 +16,7 @@ import {
   dashboardTargetB
 } from './dashboard-resolves.js';
 
-import {
-  baseDashboardChartResolves,
-  baseDashboardFsStream
-} from './base-dashboard-chart-resolves.js';
+import { baseDashboardChartResolves } from './base-dashboard-chart-resolves.js';
 
 import {
   targetDashboardResolves,
@@ -352,7 +349,6 @@ export const dashboardFsState = {
   },
   resolve: {
     charts: baseDashboardChartResolves,
-    fsStream: baseDashboardFsStream,
     getData: ['fsB', '$stateParams', getDataFn]
   }
 };

--- a/source/iml/dashboard/server-dashboard-resolves.js
+++ b/source/iml/dashboard/server-dashboard-resolves.js
@@ -51,7 +51,7 @@ export function serverDashboardHostStreamResolves(
         return x;
       },
       Nothing() {
-        throw new Error(`Unable to find target ${$stateParams.id}`);
+        throw new Error(`Unable to find server ${$stateParams.id}`);
       }
     })
   );

--- a/source/iml/dashboard/server-dashboard-resolves.js
+++ b/source/iml/dashboard/server-dashboard-resolves.js
@@ -5,11 +5,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-import * as fp from '@iml/fp';
-
 import type { HighlandStreamT } from 'highland';
-
 import type { chartT } from './dashboard-types.js';
+
+import { matchWith } from '@iml/maybe';
+import { matchById } from '../api-transforms.js';
 
 export function serverDashboardChartResolves(
   $stateParams: { id: string },
@@ -45,5 +45,14 @@ export function serverDashboardHostStreamResolves(
   hostsB: () => HighlandStreamT<Object[]>
 ) {
   'ngInject';
-  return hostsB().map(fp.filter(x => x.id === $stateParams.id)).map(x => x[0]);
+  return hostsB().map(matchById($stateParams.id)).map(
+    matchWith.bind(null, {
+      Just(x) {
+        return x;
+      },
+      Nothing() {
+        throw new Error(`Unable to find target ${$stateParams.id}`);
+      }
+    })
+  );
 }

--- a/source/iml/dashboard/target-dashboard-resolves.js
+++ b/source/iml/dashboard/target-dashboard-resolves.js
@@ -8,7 +8,8 @@
 import store from '../store/get-store.js';
 import socketStream from '../socket/socket-stream.js';
 import broadcaster from '../broadcaster.js';
-import * as fp from '@iml/fp';
+import { matchWith } from '@iml/maybe';
+import { matchById } from '../api-transforms.js';
 
 import { resolveStream } from '../promise-transforms.js';
 
@@ -55,7 +56,16 @@ export function targetDashboardResolves(
 
 export function targetDashboardTargetStream($stateParams: { id: string }) {
   'ngInject';
-  return store.select('targets').map(fp.find(x => x.id === $stateParams.id));
+  return store.select('targets').map(matchById($stateParams.id)).map(
+    matchWith.bind(null, {
+      Just(x) {
+        return x;
+      },
+      Nothing() {
+        throw new Error(`Unable to find target ${$stateParams.id}`);
+      }
+    })
+  );
 }
 
 export function targetDashboardUsageStream($stateParams: { id: string }) {

--- a/test/spec/iml/dashboard/base-dashboard-chart-resolves-test.js
+++ b/test/spec/iml/dashboard/base-dashboard-chart-resolves-test.js
@@ -1,12 +1,10 @@
-import highland from 'highland';
-
 describe('base dashboard resolves', () => {
-  let baseDashboardChartResolves, baseDashboardFsStream;
+  let baseDashboardChartResolves;
 
   beforeEach(() => {
     const mod = require('../../../../source/iml/dashboard/base-dashboard-chart-resolves.js');
 
-    ({ baseDashboardChartResolves, baseDashboardFsStream } = mod);
+    ({ baseDashboardChartResolves } = mod);
   });
 
   describe('charts', () => {
@@ -239,39 +237,6 @@ describe('base dashboard resolves', () => {
           ossChart
         ]);
       });
-    });
-  });
-
-  describe('fs stream', () => {
-    let $stateParams, fsStream, b;
-
-    beforeEach(() => {
-      $stateParams = {
-        id: 1
-      };
-      fsStream = highland();
-
-      b = baseDashboardFsStream(() => fsStream, $stateParams);
-    });
-
-    it('should stream data', () => {
-      let result;
-
-      fsStream.write([
-        {
-          id: 1,
-          foo: 'bar'
-        }
-      ]);
-
-      b().each(x => (result = x));
-
-      expect(result).toEqual([
-        {
-          id: 1,
-          foo: 'bar'
-        }
-      ]);
     });
   });
 });

--- a/test/spec/iml/dashboard/dashboard-states-test.js
+++ b/test/spec/iml/dashboard/dashboard-states-test.js
@@ -464,7 +464,6 @@ describe('dashboard states', () => {
         },
         resolve: {
           charts: 'baseDashboardChartResolves',
-          fsStream: 'baseDashboardFsStream',
           getData: ['fsB', '$stateParams', expect.any(Function)]
         }
       });

--- a/test/spec/iml/dashboard/target-dashboard-resolves-test.js
+++ b/test/spec/iml/dashboard/target-dashboard-resolves-test.js
@@ -1,5 +1,4 @@
 import highland from 'highland';
-import * as maybe from '@iml/maybe';
 
 describe('target dashboard', () => {
   let mockSocketStream,
@@ -196,21 +195,19 @@ describe('target dashboard', () => {
       targetStream.each(spy);
       s.write([
         {
-          id: '5',
+          id: 5,
           name: 'target5'
         },
         {
-          id: '1',
+          id: 1,
           name: 'target1'
         }
       ]);
 
-      expect(spy).toHaveBeenCalledWith(
-        maybe.ofJust({
-          id: '1',
-          name: 'target1'
-        })
-      );
+      expect(spy).toHaveBeenCalledWith({
+        id: 1,
+        name: 'target1'
+      });
     });
   });
 

--- a/test/spec/iml/job-stats/job-stats-resolves-test.js
+++ b/test/spec/iml/job-stats/job-stats-resolves-test.js
@@ -15,7 +15,7 @@ describe('jobstats resolves', () => {
           return highland([
             [
               {
-                id: '1',
+                id: 1,
                 name: 'foo'
               }
             ]
@@ -89,7 +89,7 @@ describe('jobstats resolves', () => {
 
     it('it should return a label when there is an id prop', async () => {
       const result = await getData({
-        id: '1',
+        id: 1,
         startDate: '2016-08-17T18:34:04.000Z',
         endDate: '2016-08-17T18:34:20.000Z'
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,12 +8,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const extractLess = new ExtractTextPlugin('[name].[contenthash].css');
 
-const pathsToClean = ['dist/*'];
+const pathsToClean = ['dist/index.html', 'dist/main.*'];
 
 const cleanOptions = {
   root: __dirname,
-  verbose: false,
-  dry: false,
   watch: true
 };
 


### PR DESCRIPTION
As discovered in https://github.com/intel-hpdd/intel-manager-for-lustre/issues/198
There are a few issues appearing with our charts. They are:

1. Target dashboard is not currently usable.
2. Server dashboard is not printing specific server.

This is due to us not unwrapping maybe types returned by find,
and not casting the API search id to an int during the find call.

Signed-off-by: Joe Grund <joe.grund@intel.com>