### PR TITLE
Fix Archive Number

### DIFF
--- a/source/iml/hsm/add-copytool-modal.js
+++ b/source/iml/hsm/add-copytool-modal.js
@@ -178,7 +178,6 @@ export function openAddCopytoolModalFactory($uibModal) {
                type="number"
                ng-model="addCopytool.copytool.archive"
                min="0"
-               ng-pattern="/^\d+$/"
                required="true"
                placeholder="Enter archive number"
         />

--- a/test/spec/iml/hsm/add-copytool-modal-test.js
+++ b/test/spec/iml/hsm/add-copytool-modal-test.js
@@ -258,7 +258,6 @@ describe('Add copytool modal', () => {
                type="number"
                ng-model="addCopytool.copytool.archive"
                min="0"
-               ng-pattern="/^\d+$/"
                required="true"
                placeholder="Enter archive number"
         />


### PR DESCRIPTION
Fixes #64.

- Typing a number in the archive field does not remove the validation
  message. This patch removes the pattern property as it is not needed.
  This will allows the field to validate properly, removing the
  validation message when an integer is entered. Letters cannot be typed
  into the input field.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>