### PR TITLE
Popover is popping under on server status page

### DIFF
--- a/source/iml/pdsh/assets/css/pdsh.less
+++ b/source/iml/pdsh/assets/css/pdsh.less
@@ -30,6 +30,7 @@
   .popover {
     top: 100% !important;
     left: 0 !important;
+    z-index: 1071;
 
     .arrow {
       left: 20px;
@@ -59,11 +60,10 @@
   width: 100%;
   display: inline-block;
 
-  ~button {
+  ~ button {
     display: inline-block;
     position: relative;
     top: 30px;
     margin-left: 4px;
   }
 }
-


### PR DESCRIPTION
Issue: https://github.com/intel-hpdd/GUI/issues/4

On the Configuration > Servers > Add More Servers

The popup that lists the desired hostnames to add was showing up behind other elements.

- Changed the .popover css z-index value to correct the stack order for the element.

Signed-off-by: Peter Robinson <peter.timothy.robinson@gmail.com>