### PR TITLE
Fix hanging dashboard streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
     "flow": "flow",
     "cover": "jest --coverage"
   },
-  "pre-commit": ["flow", "eslint", "test"],
+  "pre-commit": [
+    "flow",
+    "eslint",
+    "test"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/intel-hpdd/GUI.git"
@@ -23,7 +27,7 @@
     "@iml/debounce": "^1.0.2",
     "@iml/deep-freeze": "2.0.2",
     "@iml/extract-api": "1.0.4",
-    "@iml/flat-map-changes": "1.0.3",
+    "@iml/flat-map-changes": "1.0.4",
     "@iml/flow-highland": "4.3.0",
     "@iml/flow-jasmine": "1.6.1",
     "@iml/fp": "8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,9 +14,9 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@iml/extract-api/-/extract-api-1.0.4.tgz#82830068624f4ce6ddd634b89c3dde2551ef59c9"
 
-"@iml/flat-map-changes@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@iml/flat-map-changes/-/flat-map-changes-1.0.3.tgz#1ce0ba3500cb9d1d78b10d3b7f42df02c6d9a64c"
+"@iml/flat-map-changes@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@iml/flat-map-changes/-/flat-map-changes-1.0.4.tgz#0682dbe8bcf520a549226ed7586959bbb5361494"
   dependencies:
     highland "3.0.0-beta.4"
 


### PR DESCRIPTION
- When navigating away from the dashboard page all of the chart streams
  continue to pipe data over the websocket. The sockets should close
  after leaving the dashboard page. The problem was in flatMapChanges.
  This patch will update to flatMapChanges@1.0.4 to ensure that the
  source$ is destroyed when appropriate. This will prevent the chart
  streams from persisting between pages.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>