### PR TITLE
Fix dashboard streams

### DIFF
--- a/source/iml/storage/storage-detail-component.js
+++ b/source/iml/storage/storage-detail-component.js
@@ -311,6 +311,7 @@ export default {
 
     this.$onDestroy = () => {
       this.storageResource$.destroy();
+      this.alertIndicatorB.endBroadcast();
       Inferno.render(null, el);
     };
   }


### PR DESCRIPTION
Fix hanging dashboard streams

    - When navigating away from the dashboard page all of the chart streams
      continue to pipe data over the websocket. The sockets should close
      after leaving the dashboard page. The problem was in flatMapChanges.
      This patch will update to flatMapChanges@1.0.4 to ensure that the
      source$ is destroyed when appropriate. This will prevent the chart
      streams from persisting between pages.