### PR TITLE
Downgrade file-loader to 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-react": "^7.1.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "fastdom": "1.0.6",
-    "file-loader": "^1.0.0-rc.0",
+    "file-loader": "0.11.2",
     "flow-bin": "^0.52.0",
     "font-awesome": "4.7.0",
     "font-awesome-webpack": "^0.0.5-beta.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,9 +2081,9 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^1.0.0-rc.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.0.0.tgz#08accf9631a0875e4ab7f209fc4db338604b3190"
+file-loader@0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-0.11.2.tgz#4ff1df28af38719a6098093b88c82c71d1794a34"
   dependencies:
     loader-utils "^1.0.2"
 


### PR DESCRIPTION
 - Downgrade file-loader to 0.11.2 as the latest version is causing the fonts to be loaded with an object instead of a url.