### PR TITLE
Fixes #94.

### DIFF
--- a/source/iml/file-system/file-system-dispatch-source.js
+++ b/source/iml/file-system/file-system-dispatch-source.js
@@ -31,6 +31,8 @@ if (canDispatch())
         client_count,
         bytes_total,
         bytes_free,
+        files_total,
+        files_free,
         available_actions,
         mgt(
           primary_server_name,

--- a/test/spec/iml/file-system/file-system-dispatch-source-test.js
+++ b/test/spec/iml/file-system/file-system-dispatch-source-test.js
@@ -64,7 +64,7 @@ describe('file system dispatch source', () => {
   it('should invoke the socket stream', () => {
     expect(mockSocketStream).toHaveBeenCalledOnceWith('/filesystem', {
       jsonMask:
-        'objects(id,resource_uri,label,locks,name,client_count,bytes_total,bytes_free,available_actions,mgt(primary_server_name,primary_server),mdts(resource_uri))',
+        'objects(id,resource_uri,label,locks,name,client_count,bytes_total,bytes_free,files_total,files_free,available_actions,mgt(primary_server_name,primary_server),mdts(resource_uri))',
       qs: {
         limit: 0
       }


### PR DESCRIPTION
File information is not being displayed on the dashboard. The files
total and files used information should be displayed on the dashboard.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>