### PR TITLE
Fix Filesystem type label

### DIFF
--- a/source/iml/file-system/file-system-dispatch-source.js
+++ b/source/iml/file-system/file-system-dispatch-source.js
@@ -34,6 +34,7 @@ if (canDispatch())
         files_total,
         files_free,
         available_actions,
+        immutable_state,
         mgt(
           primary_server_name,
           primary_server

--- a/test/spec/iml/file-system/file-system-dispatch-source-test.js
+++ b/test/spec/iml/file-system/file-system-dispatch-source-test.js
@@ -64,7 +64,7 @@ describe('file system dispatch source', () => {
   it('should invoke the socket stream', () => {
     expect(mockSocketStream).toHaveBeenCalledOnceWith('/filesystem', {
       jsonMask:
-        'objects(id,resource_uri,label,locks,name,client_count,bytes_total,bytes_free,files_total,files_free,available_actions,mgt(primary_server_name,primary_server),mdts(resource_uri))',
+        'objects(id,resource_uri,label,locks,name,client_count,bytes_total,bytes_free,files_total,files_free,available_actions,immutable_state,mgt(primary_server_name,primary_server),mdts(resource_uri))',
       qs: {
         limit: 0
       }


### PR DESCRIPTION
The filesystem type always displays as "managed" on the dashboard. This
is because the "immutable_state" property was not included in the json
mask. After adding this property, the filesystem type lable now shows
"monitored" when working with a monitored filesystem.

Signed-off-by: Will Johnson <william.c1.johnson@gmail.com>