### PR TITLE
Change order of profiles

### DIFF
--- a/source/iml/server/select-server-profile-step.js
+++ b/source/iml/server/select-server-profile-step.js
@@ -64,11 +64,17 @@ export function SelectServerProfileStepCtrl(
 
   hostProfileStream
     .tap(function(profiles) {
-      profiles.sort(function sortProfiles(a, b) {
-        if (a.invalid === true) return 1;
-        else if (b.invalid === true) return -1;
-        else return 0;
-      });
+      profiles
+        .sort(function sortProfiles(a, b) {
+          if (a.invalid === true) return 1;
+          else if (b.invalid === true) return -1;
+          else return 0;
+        })
+        .sort((a, b) => {
+          if (a.name === 'base_monitored') return -1;
+          else if (b.name === 'base_monitored') return 1;
+          else return 0;
+        });
 
       selectServerProfileStep.profiles = profiles;
 

--- a/source/iml/server/select-server-profile-step.js
+++ b/source/iml/server/select-server-profile-step.js
@@ -65,7 +65,7 @@ export function SelectServerProfileStepCtrl(
   hostProfileStream
     .tap(function(profiles) {
       profiles
-        .sort(function sortProfiles(a, b) {
+        .sort((a, b) => {
           if (a.invalid === true) return 1;
           else if (b.invalid === true) return -1;
           else return 0;

--- a/test/spec/iml/server/__snapshots__/select-server-profile-step-test.js.snap
+++ b/test/spec/iml/server/__snapshots__/select-server-profile-step-test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`select server profile select server profile step ctrl profile stream should display in the correct order 1`] = `
+Array [
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Monitored Storage Server",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Monitored Storage Server",
+      },
+    ],
+    "invalid": false,
+    "name": "base_monitored",
+    "uiName": "Monitored Storage Server",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "ZFS is installed but is unsupported by the Managed Storage Server profile",
+            "error": "Result unavailable while host agent starts",
+            "pass": false,
+            "test": "zfs_installed == False",
+          },
+        ],
+        "uiName": "Managed Storage Server",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "ZFS is installed but is unsupported by the Managed Storage Server profile",
+            "error": "Result unavailable while host agent starts",
+            "pass": false,
+            "test": "zfs_installed == False",
+          },
+        ],
+        "uiName": "Managed Storage Server",
+      },
+    ],
+    "invalid": false,
+    "name": "base_managed",
+    "uiName": "Managed Storage Server",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "The profile is designed for version 7 of EL",
+            "error": "",
+            "pass": false,
+            "test": "distro_version < 8 and distro_version >= 7",
+          },
+        ],
+        "uiName": "Managed Storage Server For EL7.2",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "The profile is designed for version 7 of EL",
+            "error": "",
+            "pass": false,
+            "test": "distro_version < 8 and distro_version >= 7",
+          },
+        ],
+        "uiName": "Managed Storage Server For EL7.2",
+      },
+    ],
+    "invalid": false,
+    "name": "base_managed_rh7",
+    "uiName": "Managed Storage Server For EL7.2",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "POSIX HSM Agent Node",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "POSIX HSM Agent Node",
+      },
+    ],
+    "invalid": false,
+    "name": "posix_copytool_worker",
+    "uiName": "POSIX HSM Agent Node",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Robinhood Policy Engine Server",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Robinhood Policy Engine Server",
+      },
+    ],
+    "invalid": false,
+    "name": "robinhood_server",
+    "uiName": "Robinhood Policy Engine Server",
+  },
+]
+`;

--- a/test/spec/iml/server/__snapshots__/select-server-profile-step-test.js.snap
+++ b/test/spec/iml/server/__snapshots__/select-server-profile-step-test.js.snap
@@ -127,3 +127,131 @@ Array [
   },
 ]
 `;
+
+exports[`select server profile select server profile step ctrl profile stream with invalid profiles should display in the correct order 1`] = `
+Array [
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Monitored Storage Server",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Monitored Storage Server",
+      },
+    ],
+    "invalid": false,
+    "name": "base_monitored",
+    "uiName": "Monitored Storage Server",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "POSIX HSM Agent Node",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "POSIX HSM Agent Node",
+      },
+    ],
+    "invalid": false,
+    "name": "posix_copytool_worker",
+    "uiName": "POSIX HSM Agent Node",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Robinhood Policy Engine Server",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": false,
+        "problems": Array [],
+        "uiName": "Robinhood Policy Engine Server",
+      },
+    ],
+    "invalid": false,
+    "name": "robinhood_server",
+    "uiName": "Robinhood Policy Engine Server",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "The profile is designed for version 7 of EL",
+            "error": "",
+            "pass": false,
+            "test": "distro_version < 8 and distro_version >= 7",
+          },
+        ],
+        "uiName": "Managed Storage Server For EL7.2",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "The profile is designed for version 7 of EL",
+            "error": "",
+            "pass": false,
+            "test": "distro_version < 8 and distro_version >= 7",
+          },
+        ],
+        "uiName": "Managed Storage Server For EL7.2",
+      },
+    ],
+    "invalid": true,
+    "name": "base_managed_rh7",
+    "uiName": "Managed Storage Server For EL7.2",
+  },
+  Object {
+    "hosts": Array [
+      Object {
+        "address": "lotus-34vm5.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "ZFS is installed but is unsupported by the Managed Storage Server profile",
+            "error": "Result unavailable while host agent starts",
+            "pass": false,
+            "test": "zfs_installed == False",
+          },
+        ],
+        "uiName": "Managed Storage Server",
+      },
+      Object {
+        "address": "lotus-34vm6.iml.intel.com",
+        "invalid": true,
+        "problems": Array [
+          Object {
+            "description": "ZFS is installed but is unsupported by the Managed Storage Server profile",
+            "error": "Result unavailable while host agent starts",
+            "pass": false,
+            "test": "zfs_installed == False",
+          },
+        ],
+        "uiName": "Managed Storage Server",
+      },
+    ],
+    "invalid": true,
+    "name": "base_managed",
+    "uiName": "Managed Storage Server",
+  },
+]
+`;

--- a/test/spec/iml/server/select-server-profile-step-test.js
+++ b/test/spec/iml/server/select-server-profile-step-test.js
@@ -127,6 +127,23 @@ describe('select server profile', () => {
       });
     });
 
+    describe('profile stream', () => {
+      beforeEach(() => {
+        const hostProfileFixture = require('../../../data-fixtures/transformed-host-profile-fixture.json');
+        const setValid = x => {
+          x.invalid = false;
+          return x;
+        }
+        const hostProfiles = fp.map(setValid)(hostProfileFixture);
+
+        hostProfileStream.write(hostProfiles);
+      });
+
+      it('should display in the correct order', () => {
+        expect(selectServerProfileStep.profiles).toMatchSnapshot();
+      });
+    });
+
     describe('get host path', () => {
       let item;
       beforeEach(() => {

--- a/test/spec/iml/server/select-server-profile-step-test.js
+++ b/test/spec/iml/server/select-server-profile-step-test.js
@@ -128,19 +128,27 @@ describe('select server profile', () => {
     });
 
     describe('profile stream', () => {
+      let hostProfileFixture;
       beforeEach(() => {
-        const hostProfileFixture = require('../../../data-fixtures/transformed-host-profile-fixture.json');
-        const setValid = x => {
-          x.invalid = false;
-          return x;
-        }
-        const hostProfiles = fp.map(setValid)(hostProfileFixture);
-
-        hostProfileStream.write(hostProfiles);
+        hostProfileFixture = require('../../../data-fixtures/transformed-host-profile-fixture.json');
       });
 
       it('should display in the correct order', () => {
+        const setValid = x => {
+          x.invalid = false;
+          return x;
+        };
+        const hostProfiles = fp.map(setValid)(hostProfileFixture);
+
+        hostProfileStream.write(hostProfiles);
         expect(selectServerProfileStep.profiles).toMatchSnapshot();
+      });
+
+      describe('with invalid profiles', () => {
+        it('should display in the correct order', () => {
+          hostProfileStream.write(hostProfileFixture);
+          expect(selectServerProfileStep.profiles).toMatchSnapshot();
+        });
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/intel-hpdd/intel-manager-for-lustre/issues/406

Set monitored mode to be the first profile on the select profile screen.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>